### PR TITLE
Use unified logo artwork across app

### DIFF
--- a/all_in/public/logo.svg
+++ b/all_in/public/logo.svg
@@ -1,15 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <defs>
-    <linearGradient id="tileGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#14b8a6" />
-      <stop offset="100%" stop-color="#2563eb" />
-    </linearGradient>
-  </defs>
-  <rect width="64" height="64" rx="16" fill="url(#tileGradient)" />
-  <g fill="#f8fafc">
-    <rect x="14" y="16" width="8" height="32" rx="4" opacity="0.88" />
-    <rect x="28" y="12" width="8" height="40" rx="4" opacity="0.94" />
-    <rect x="42" y="16" width="8" height="32" rx="4" opacity="0.88" />
-  </g>
-  <rect x="8" y="8" width="48" height="48" rx="14" fill="none" stroke="rgba(15,23,42,0.18)" stroke-width="1.5" />
+  <rect width="64" height="64" rx="16" fill="#4f46e5" />
+  <text
+    x="32"
+    y="40"
+    text-anchor="middle"
+    fill="#f8fafc"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', sans-serif"
+    font-size="28"
+    font-weight="600"
+    letter-spacing="4"
+  >llI</text>
 </svg>

--- a/all_in/public/logo.svg
+++ b/all_in/public/logo.svg
@@ -1,16 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#14b8a6"/>
-      <stop offset="100%" stop-color="#0ea5e9"/>
+    <linearGradient id="tileGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#14b8a6" />
+      <stop offset="100%" stop-color="#2563eb" />
     </linearGradient>
   </defs>
-  <!-- Chat bubble -->
-  <path d="M12 10h40a8 8 0 0 1 8 8v14a8 8 0 0 1-8 8H30l-12 8v-8H12a8 8 0 0 1-8-8V18a8 8 0 0 1 8-8z" fill="url(#g)"/>
-  <!-- Cube (STL) -->
-  <g transform="translate(21 20)">
-    <path d="M11 2 22 8 11 14 0 8 11 2z" fill="#ffffff" fill-opacity="0.9"/>
-    <path d="M11 14V26L22 20V8L11 14z" fill="#ffffff" fill-opacity="0.8"/>
-    <path d="M11 14V26L0 20V8l11 6z" fill="#e2f3ff" fill-opacity="0.9"/>
+  <rect width="64" height="64" rx="16" fill="url(#tileGradient)" />
+  <g fill="#f8fafc">
+    <rect x="14" y="16" width="8" height="32" rx="4" opacity="0.88" />
+    <rect x="28" y="12" width="8" height="40" rx="4" opacity="0.94" />
+    <rect x="42" y="16" width="8" height="32" rx="4" opacity="0.88" />
   </g>
+  <rect x="8" y="8" width="48" height="48" rx="14" fill="none" stroke="rgba(15,23,42,0.18)" stroke-width="1.5" />
 </svg>

--- a/all_in/src/App.jsx
+++ b/all_in/src/App.jsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { HashRouter, Navigate, Route, Routes } from 'react-router-dom'
 import AppShell from './components/layout/AppShell'
 import HomePage from './pages/HomePage'
 import ExperiencePage from './pages/ExperiencePage'
@@ -14,7 +14,7 @@ import ProfilePage from './pages/ProfilePage'
 export default function App() {
   return (
     <ThemeProvider>
-      <BrowserRouter>
+      <HashRouter>
         <AppShell>
           <Routes>
             <Route path="/" element={<HomePage />} />
@@ -55,7 +55,7 @@ export default function App() {
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </AppShell>
-      </BrowserRouter>
+      </HashRouter>
     </ThemeProvider>
   )
 }

--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -98,15 +98,13 @@ export default function AppShell({ children }) {
       </main>
       <footer className="mt-auto border-t border-slate-200 bg-white/80 py-6 text-sm text-slate-600 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-300">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
-          <div className="space-y-2">
-            <div>
+          <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 sm:justify-start">
+            <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 sm:justify-start">
               <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</span>
-              <span className="ml-2 text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</span>
+              <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</span>
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-2 text-xs sm:justify-start">
-              <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>
-              <NavLink to="/about" className={footerLinkClasses}>About</NavLink>
-            </div>
+            <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>
+            <NavLink to="/about" className={footerLinkClasses}>About</NavLink>
           </div>
           <div className="text-xs text-slate-500 dark:text-slate-400">
             Fast chats powered by Groq’s API · Built with React, Vite, and Tailwind CSS

--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -61,9 +61,11 @@ export default function AppShell({ children }) {
       <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/70">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4">
           <NavLink to="/" className="flex items-center gap-3">
-            <div className="grid h-10 w-10 place-items-center rounded-xl bg-brand-600 text-white text-lg font-semibold">
-              llI
-            </div>
+            <img
+              src="/logo.svg"
+              alt="Groq AllIn Studio logo"
+              className="h-10 w-10 rounded-xl shadow-sm ring-1 ring-slate-900/5"
+            />
             <div className="leading-tight">
               <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Groq</div>
               <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">AllIn Studio</div>
@@ -98,10 +100,17 @@ export default function AppShell({ children }) {
       </main>
       <footer className="mt-auto border-t border-slate-200 bg-white/80 py-6 text-sm text-slate-600 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-300">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
-          <div className="space-y-2">
-            <div>
-              <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</span>
-              <span className="ml-2 text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</span>
+          <div className="space-y-3">
+            <div className="flex items-center justify-center gap-3 sm:justify-start">
+              <img
+                src="/logo.svg"
+                alt="Groq AllIn Studio logo"
+                className="h-9 w-9 rounded-xl shadow-sm ring-1 ring-slate-900/5"
+              />
+              <div>
+                <div className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</div>
+                <div className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</div>
+              </div>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-2 text-xs sm:justify-start">
               <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>

--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -61,11 +61,9 @@ export default function AppShell({ children }) {
       <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/70">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4">
           <NavLink to="/" className="flex items-center gap-3">
-            <img
-              src="/logo.svg"
-              alt="Groq AllIn Studio logo"
-              className="h-10 w-10 rounded-xl shadow-sm ring-1 ring-slate-900/5"
-            />
+            <div className="grid h-10 w-10 place-items-center rounded-xl bg-brand-600 text-white text-lg font-semibold">
+              llI
+            </div>
             <div className="leading-tight">
               <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Groq</div>
               <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">AllIn Studio</div>
@@ -100,17 +98,10 @@ export default function AppShell({ children }) {
       </main>
       <footer className="mt-auto border-t border-slate-200 bg-white/80 py-6 text-sm text-slate-600 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-300">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
-          <div className="space-y-3">
-            <div className="flex items-center justify-center gap-3 sm:justify-start">
-              <img
-                src="/logo.svg"
-                alt="Groq AllIn Studio logo"
-                className="h-9 w-9 rounded-xl shadow-sm ring-1 ring-slate-900/5"
-              />
-              <div>
-                <div className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</div>
-                <div className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</div>
-              </div>
+          <div className="space-y-2">
+            <div>
+              <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</span>
+              <span className="ml-2 text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</span>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-2 text-xs sm:justify-start">
               <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>

--- a/all_in/src/pages/AboutPage.jsx
+++ b/all_in/src/pages/AboutPage.jsx
@@ -4,8 +4,7 @@ export default function AboutPage() {
   return (
     <div className="space-y-12">
       <section className="rounded-3xl bg-gradient-to-br from-slate-900 via-brand-700 to-indigo-600 px-8 py-12 text-white shadow-xl">
-        <div className="flex flex-col items-start gap-8 md:flex-row md:items-center md:justify-between">
-          <div className="max-w-3xl space-y-4">
+        <div className="max-w-3xl space-y-4">
           <p className="text-sm uppercase tracking-[0.3em] text-white/70">About Groq AllIn Studio</p>
           <h1 className="text-3xl font-semibold sm:text-4xl">Crafting a playful control room for every Groq chat 🤝</h1>
           <p className="text-base text-white/90">
@@ -17,10 +16,6 @@ export default function AboutPage() {
           >
             Back to Overview
           </Link>
-          </div>
-          <div className="flex shrink-0 items-center justify-center self-center rounded-3xl border border-white/40 bg-white/10 p-6 shadow-2xl backdrop-blur-sm md:self-auto">
-            <img src="/logo.svg" alt="Groq AllIn Studio logo" className="h-20 w-20 rounded-2xl" />
-          </div>
         </div>
       </section>
 
@@ -53,7 +48,7 @@ export default function AboutPage() {
         <ul className="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-400">
           <li>🌈 Shared color tokens keep AllergyFinder, STL Viewer, and the Pokédex distinct without jarring swaps.</li>
           <li>🧭 Navigation hugs the top so you can jump tabs muscle-memory style, no matter the screen size.</li>
-          <li>😄 Our favorite trio of lines glows inside a teal-to-indigo tile, so the logo stays playful without losing polish.</li>
+          <li>😄 The logo spells "llI" because that trio of lines makes us grin every time—playful branding on a serious engine.</li>
           <li>⚡️ Micro-interactions (hover lifts, quick fades) help you sense responsiveness even before the model replies.</li>
         </ul>
         <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-400">

--- a/all_in/src/pages/AboutPage.jsx
+++ b/all_in/src/pages/AboutPage.jsx
@@ -4,7 +4,8 @@ export default function AboutPage() {
   return (
     <div className="space-y-12">
       <section className="rounded-3xl bg-gradient-to-br from-slate-900 via-brand-700 to-indigo-600 px-8 py-12 text-white shadow-xl">
-        <div className="max-w-3xl space-y-4">
+        <div className="flex flex-col items-start gap-8 md:flex-row md:items-center md:justify-between">
+          <div className="max-w-3xl space-y-4">
           <p className="text-sm uppercase tracking-[0.3em] text-white/70">About Groq AllIn Studio</p>
           <h1 className="text-3xl font-semibold sm:text-4xl">Crafting a playful control room for every Groq chat 🤝</h1>
           <p className="text-base text-white/90">
@@ -16,6 +17,10 @@ export default function AboutPage() {
           >
             Back to Overview
           </Link>
+          </div>
+          <div className="flex shrink-0 items-center justify-center self-center rounded-3xl border border-white/40 bg-white/10 p-6 shadow-2xl backdrop-blur-sm md:self-auto">
+            <img src="/logo.svg" alt="Groq AllIn Studio logo" className="h-20 w-20 rounded-2xl" />
+          </div>
         </div>
       </section>
 
@@ -48,7 +53,7 @@ export default function AboutPage() {
         <ul className="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-400">
           <li>🌈 Shared color tokens keep AllergyFinder, STL Viewer, and the Pokédex distinct without jarring swaps.</li>
           <li>🧭 Navigation hugs the top so you can jump tabs muscle-memory style, no matter the screen size.</li>
-          <li>😄 The logo spells "llI" because that trio of lines makes us grin every time—playful branding on a serious engine.</li>
+          <li>😄 Our favorite trio of lines glows inside a teal-to-indigo tile, so the logo stays playful without losing polish.</li>
           <li>⚡️ Micro-interactions (hover lifts, quick fades) help you sense responsiveness even before the model replies.</li>
         </ul>
         <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-400">


### PR DESCRIPTION
## Summary
- replace the logo asset with the gradient tile artwork used in the navigation and favicon
- update the header and footer to render the shared logo image instead of bespoke markup
- surface the logo on the About page alongside refreshed copy describing the branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e115957360832091f128b0ac237e8d