### PR TITLE
Add AllIn Studio illustration banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # groq_funny_stuff
 
+![Illustration banner showing the Groq AllIn Studio experiences](all_in/allin_illustration_banner.png)
+
 Groq AllIn Studio is the flagship experience in this repo: a single React workspace that bundles the Pokédex, AllergyFinder, and STL viewer demos behind one shell. The live deployment is available at https://groq-allin.thefrenchartist.dev/. The legacy folders remain for focused local work, but only `all_in` is packaged for production.
 
 ## Overview


### PR DESCRIPTION
## Summary
- embed the Groq AllIn Studio illustration banner at the top of the root README for better visual context

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e17e76ff3c8320b1e05ca42da3637d