### PR TITLE
Refine copy across Groq AllIn Studio

### DIFF
--- a/all_in/src/components/Sidebar.jsx
+++ b/all_in/src/components/Sidebar.jsx
@@ -22,7 +22,7 @@ export default function Sidebar({
         disabled={disableNew}
         className="mb-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-brand-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-brand-600/60"
       >
-        <PlusIcon className="h-5 w-5" /> New chat
+        <PlusIcon className="h-5 w-5" /> New chat ✨
       </button>
       {onFlushHistory ? (
         <button
@@ -31,7 +31,7 @@ export default function Sidebar({
           disabled={disableFlush}
           className="mb-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800"
         >
-          <TrashIcon className="h-5 w-5" /> Delete saved chats
+          <TrashIcon className="h-5 w-5" /> Delete saved chats 🗑️
         </button>
       ) : null}
       <div className="space-y-1">

--- a/all_in/src/components/Sidebar.jsx
+++ b/all_in/src/components/Sidebar.jsx
@@ -31,7 +31,7 @@ export default function Sidebar({
           disabled={disableFlush}
           className="mb-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800"
         >
-          <TrashIcon className="h-5 w-5" /> Flush saved chats
+          <TrashIcon className="h-5 w-5" /> Delete saved chats
         </button>
       ) : null}
       <div className="space-y-1">

--- a/all_in/src/components/allergyfinder/AllergyCookieEditor.jsx
+++ b/all_in/src/components/allergyfinder/AllergyCookieEditor.jsx
@@ -22,28 +22,28 @@ export default function AllergyCookieEditor() {
   function handleSave(event) {
     event.preventDefault()
     writeAllergyCookie(notes || '')
-    setStatus({ type: 'success', message: 'Allergy notes saved to cookie.' })
+    setStatus({ type: 'success', message: 'Allergy notes saved to cookie. ✅' })
   }
 
   function handleFlush() {
     flushAllCookies()
     setNotes('')
-    setStatus({ type: 'warning', message: 'All cookies cleared for this site.' })
+    setStatus({ type: 'warning', message: 'All cookies cleared for this site. ⚠️' })
   }
 
   return (
     <div className="space-y-6">
       <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-6 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-100">
-        <h2 className="text-xl font-semibold">Allergy Cookie Editor</h2>
+        <h2 className="text-xl font-semibold">Allergy Cookie Editor 🍪</h2>
         <p className="mt-2 text-sm text-emerald-900/80 dark:text-emerald-100/80">
-          Save a markdown list of allergens you or your household need to watch out for. The notes are stored in a browser
+          📝 Save a markdown list of allergens you or your household need to watch out for. The notes are stored in a browser
           cookie so you can quickly reference or reuse them when chatting with the assistant.
         </p>
       </div>
 
       <form className="space-y-4" onSubmit={handleSave}>
         <label className="block space-y-2" htmlFor="allergy-cookie-textarea">
-          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Allergy list</span>
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Allergy list 📋</span>
           <textarea
             id="allergy-cookie-textarea"
             name="allergy-notes"
@@ -56,21 +56,21 @@ export default function AllergyCookieEditor() {
           />
         </label>
         <p id="allergy-cookie-helper" className="text-xs text-slate-500 dark:text-slate-400">
-          {`Tip: This information is stored in the "${ALLERGY_COOKIE_NAME}" browser cookie. Use markdown lists, headings, or bold text to organise allergens by family members.`}
+          {`Tip: This information is stored in the "${ALLERGY_COOKIE_NAME}" browser cookie. Use markdown lists, headings, or bold text to organise allergens by family members. 💡`}
         </p>
         <div className="flex flex-wrap items-center gap-3">
           <button
             type="submit"
             className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 disabled:opacity-50"
           >
-            Save Cookie
+            Save Cookie 💾
           </button>
           <button
             type="button"
             onClick={handleFlush}
             className="inline-flex items-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus-visible:outline-slate-500"
           >
-            Delete All Cookies
+            Delete All Cookies 🧹
           </button>
           {status ? (
             <span

--- a/all_in/src/components/allergyfinder/AllergyCookieEditor.jsx
+++ b/all_in/src/components/allergyfinder/AllergyCookieEditor.jsx
@@ -36,8 +36,8 @@ export default function AllergyCookieEditor() {
       <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-6 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-100">
         <h2 className="text-xl font-semibold">Allergy Cookie Editor</h2>
         <p className="mt-2 text-sm text-emerald-900/80 dark:text-emerald-100/80">
-          Save a markdown list of allergens you or your household need to watch out for. We will store it as a
-          browser cookie so you can quickly reference or reuse it when chatting with the assistant.
+          Save a markdown list of allergens you or your household need to watch out for. The notes are stored in a browser
+          cookie so you can quickly reference or reuse them when chatting with the assistant.
         </p>
       </div>
 
@@ -56,7 +56,7 @@ export default function AllergyCookieEditor() {
           />
         </label>
         <p id="allergy-cookie-helper" className="text-xs text-slate-500 dark:text-slate-400">
-          {`Tip: We'll store this in the "${ALLERGY_COOKIE_NAME}" browser cookie. Use markdown lists, headings, or bold text to organise allergens by family members.`}
+          {`Tip: This information is stored in the "${ALLERGY_COOKIE_NAME}" browser cookie. Use markdown lists, headings, or bold text to organise allergens by family members.`}
         </p>
         <div className="flex flex-wrap items-center gap-3">
           <button
@@ -70,7 +70,7 @@ export default function AllergyCookieEditor() {
             onClick={handleFlush}
             className="inline-flex items-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:bg-slate-800 dark:focus-visible:outline-slate-500"
           >
-            Flush All Cookies
+            Delete All Cookies
           </button>
           {status ? (
             <span

--- a/all_in/src/components/allergyfinder/UserProfile.jsx
+++ b/all_in/src/components/allergyfinder/UserProfile.jsx
@@ -94,9 +94,9 @@ export default function UserProfile() {
   return (
     <div className="space-y-10">
       <section className="rounded-3xl border border-emerald-200 bg-emerald-50/70 p-6 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-100">
-        <h2 className="text-2xl font-semibold">User Profile</h2>
+        <h2 className="text-2xl font-semibold">User Profile 👤</h2>
         <p className="mt-2 text-sm text-emerald-900/80 dark:text-emerald-100/80">
-          The application generates a display alias so you can save notes without revealing personal details. Your profile name
+          🔐 The application generates a display alias so you can save notes without revealing personal details. Your profile name
           lives in a browser cookie on this device.
         </p>
         <div className="mt-6 flex flex-wrap items-center gap-4">
@@ -108,35 +108,35 @@ export default function UserProfile() {
             onClick={handleRegenerateProfile}
             className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-500"
           >
-            Generate New Alias
+            Generate New Alias 🎲
           </button>
           <button
             type="button"
             onClick={handleFlushProfile}
             className="inline-flex items-center rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500"
           >
-            Remove Profile Cookie
+            Remove Profile Cookie 🗑️
           </button>
         </div>
         <p className="mt-3 rounded-2xl border border-red-300 bg-red-50/80 p-3 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
           Important: Removing the profile cookie deletes the saved alias immediately. The next time you open this page a new
-          randomly generated name will appear.
+          randomly generated name will appear. ⚠️
         </p>
       </section>
 
       <section className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Saved Allergies</h3>
+          <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Saved Allergies 🗂️</h3>
           <Link
             to="/allergyfinder/cookies"
             className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500"
           >
-            Edit Allergy List
+            Edit Allergy List ✍️
           </Link>
         </div>
         <div className="rounded-3xl border border-emerald-200 bg-white/85 p-5 shadow-sm dark:border-emerald-500/40 dark:bg-emerald-900/20">
           <div className="text-3xl font-bold text-emerald-700 dark:text-emerald-200">{allergyCount}</div>
-          <div className="text-sm text-slate-600 dark:text-slate-300">Allergens listed across your saved markdown notes.</div>
+          <div className="text-sm text-slate-600 dark:text-slate-300">Allergens listed across your saved markdown notes. 📊</div>
           <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4 text-sm text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-900/40 dark:text-emerald-100">
             {allergyItems.length > 0 ? (
               <ul className="list-disc space-y-1 pl-5">
@@ -145,13 +145,13 @@ export default function UserProfile() {
                 ))}
                 {allergyCount > allergyItems.length ? (
                   <li className="italic text-emerald-700/80 dark:text-emerald-200/80">
-                    …and {allergyCount - allergyItems.length} more allergens saved.
+                    …and {allergyCount - allergyItems.length} more allergens saved. ➕
                   </li>
                 ) : null}
               </ul>
             ) : (
               <div className="italic text-emerald-700/80 dark:text-emerald-200/80">
-                No allergy notes saved yet.
+                No allergy notes saved yet. 🕒
               </div>
             )}
           </div>
@@ -161,10 +161,10 @@ export default function UserProfile() {
             onClick={handleFlushAllergyData}
             className="inline-flex items-center rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500"
           >
-            Delete Allergy Notes & Saved Chats
+            Delete Allergy Notes & Saved Chats 🧹
           </button>
           <p className="rounded-xl border border-red-300 bg-red-50/80 px-4 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
-            Important: This removes the allergy notes cookie and any saved AllergyFinder conversations from this browser.
+            Important: This removes the allergy notes cookie and any saved AllergyFinder conversations from this browser. ⚠️
           </p>
           </div>
         </div>
@@ -172,9 +172,9 @@ export default function UserProfile() {
 
       <section className="space-y-6">
         <div>
-          <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Chat Activity</h3>
+          <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Chat Activity 📈</h3>
           <p className="text-sm text-slate-600 dark:text-slate-400">We snapshot how many conversations you have started in each
-            demo. Counts are stored locally in a cookie.</p>
+            demo. Counts are stored locally in a cookie. 🧮</p>
         </div>
         <div className="grid gap-4 md:grid-cols-3">
           {Object.entries(chatCounts).map(([experienceId, count]) => (
@@ -191,11 +191,11 @@ export default function UserProfile() {
                 onClick={() => handleFlushCount(experienceId)}
                 className="inline-flex items-center rounded-xl bg-red-600 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-red-500"
               >
-                Delete {EXPERIENCE_LABELS[experienceId] || experienceId} History
+                Delete {EXPERIENCE_LABELS[experienceId] || experienceId} History 🗑️
               </button>
               <p className="rounded-lg border border-red-200 bg-red-50/80 p-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
                 Important: This deletes the saved cookie for this experience. Any stored conversations and counters are
-                permanently removed from this browser.
+                permanently removed from this browser. ⚠️
               </p>
             </div>
           ))}
@@ -206,10 +206,10 @@ export default function UserProfile() {
             onClick={handleFlushAllCounts}
             className="inline-flex items-center rounded-xl bg-red-700 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-red-600"
           >
-            Delete All Saved Chat History
+            Delete All Saved Chat History 🧽
           </button>
           <p className="rounded-xl border border-red-300 bg-red-50/90 px-4 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/40 dark:text-red-200">
-            Important: This deletes every saved chat cookie across AllergyFinder, STL Studio, and the Pokédex on this device.
+            Important: This deletes every saved chat cookie across AllergyFinder, STL Studio, and the Pokédex on this device. ⚠️
           </p>
         </div>
       </section>

--- a/all_in/src/components/allergyfinder/UserProfile.jsx
+++ b/all_in/src/components/allergyfinder/UserProfile.jsx
@@ -96,8 +96,8 @@ export default function UserProfile() {
       <section className="rounded-3xl border border-emerald-200 bg-emerald-50/70 p-6 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-100">
         <h2 className="text-2xl font-semibold">User Profile</h2>
         <p className="mt-2 text-sm text-emerald-900/80 dark:text-emerald-100/80">
-          We generate a friendly alias so you can save notes without revealing personal details. Your profile name lives in a
-          browser cookie on this device.
+          The application generates a display alias so you can save notes without revealing personal details. Your profile name
+          lives in a browser cookie on this device.
         </p>
         <div className="mt-6 flex flex-wrap items-center gap-4">
           <div className="rounded-2xl bg-white/80 px-5 py-4 text-lg font-semibold text-emerald-700 shadow-sm dark:bg-slate-900/40 dark:text-emerald-200">
@@ -115,12 +115,12 @@ export default function UserProfile() {
             onClick={handleFlushProfile}
             className="inline-flex items-center rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-500"
           >
-            Delete Profile Cookie
+            Remove Profile Cookie
           </button>
         </div>
         <p className="mt-3 rounded-2xl border border-red-300 bg-red-50/80 p-3 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
-          Warning: Deleting the profile cookie removes your saved alias immediately. The next time you open this page a new random
-          name will be generated.
+          Important: Removing the profile cookie deletes the saved alias immediately. The next time you open this page a new
+          randomly generated name will appear.
         </p>
       </section>
 
@@ -164,7 +164,7 @@ export default function UserProfile() {
             Delete Allergy Notes & Saved Chats
           </button>
           <p className="rounded-xl border border-red-300 bg-red-50/80 px-4 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
-            Critical warning: This removes the allergy notes cookie and any saved AllergyFinder conversations from this browser.
+            Important: This removes the allergy notes cookie and any saved AllergyFinder conversations from this browser.
           </p>
           </div>
         </div>
@@ -194,8 +194,8 @@ export default function UserProfile() {
                 Delete {EXPERIENCE_LABELS[experienceId] || experienceId} History
               </button>
               <p className="rounded-lg border border-red-200 bg-red-50/80 p-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200">
-                Warning: This deletes the saved cookie for this experience. Any stored conversations and counters are permanently
-                removed from this browser.
+                Important: This deletes the saved cookie for this experience. Any stored conversations and counters are
+                permanently removed from this browser.
               </p>
             </div>
           ))}
@@ -209,7 +209,7 @@ export default function UserProfile() {
             Delete All Saved Chat History
           </button>
           <p className="rounded-xl border border-red-300 bg-red-50/90 px-4 py-2 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/40 dark:text-red-200">
-            Warning: This deletes every saved chat cookie across AllergyFinder, STL Studio, and the Pokédex on this device.
+            Important: This deletes every saved chat cookie across AllergyFinder, STL Studio, and the Pokédex on this device.
           </p>
         </div>
       </section>

--- a/all_in/src/components/chat/MessageBubble.jsx
+++ b/all_in/src/components/chat/MessageBubble.jsx
@@ -83,19 +83,19 @@ export default function MessageBubble({ experience, role, content, name, timesta
         {enableStl && stlSources.length > 0 && !streaming && (
           <div className="mt-2">
             <ErrorBoundary>
-              <Suspense fallback={<div className="h-64 grid place-items-center text-slate-500">Loading 3D viewer...</div>}>
+              <Suspense fallback={<div className="h-64 grid place-items-center text-slate-500">Loading 3D viewer… ⏳</div>}>
                 <STLViewer source={stlSources[0]} />
               </Suspense>
             </ErrorBoundary>
           </div>
         )}
         {enableStl && stlSources.length > 0 && streaming && (
-          <div className="mt-2 text-xs text-slate-500">3D preview will appear when the response finishes...</div>
+          <div className="mt-2 text-xs text-slate-500">3D preview will appear when the response finishes… 🛰️</div>
         )}
         {enableStl && stlSources.length === 0 && !streaming && maybeStl && (
           <div className="mt-2 text-xs text-amber-600 dark:text-amber-400">
             The response looks like STL content but may be incomplete. Wrap it in a fenced block (```stl … ```), or include
-            full facets so the preview can render correctly.
+            full facets so the preview can render correctly. 🧱
           </div>
         )}
       </div>

--- a/all_in/src/components/chat/MessageBubble.jsx
+++ b/all_in/src/components/chat/MessageBubble.jsx
@@ -94,7 +94,8 @@ export default function MessageBubble({ experience, role, content, name, timesta
         )}
         {enableStl && stlSources.length === 0 && !streaming && maybeStl && (
           <div className="mt-2 text-xs text-amber-600 dark:text-amber-400">
-            Looks like STL text, but it may be incomplete. Wrap it in a fenced block (```stl ... ```), or include full facets.
+            The response looks like STL content but may be incomplete. Wrap it in a fenced block (```stl … ```), or include
+            full facets so the preview can render correctly.
           </div>
         )}
       </div>

--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -66,7 +66,7 @@ export default function AppShell({ children }) {
             </div>
             <div className="leading-tight">
               <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Groq</div>
-              <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">AllIn Studio</div>
+              <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">AllIn Studio 🌐</div>
             </div>
           </NavLink>
           <nav className="hidden items-center gap-2 md:flex">
@@ -100,14 +100,14 @@ export default function AppShell({ children }) {
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 sm:justify-start">
             <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 sm:justify-start">
-              <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</span>
-              <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Workspace</span>
+              <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio 💼</span>
+              <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Workspace ⚙️</span>
             </div>
             <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>
             <NavLink to="/about" className={footerLinkClasses}>About</NavLink>
           </div>
           <div className="text-xs text-slate-500 dark:text-slate-400">
-            Fast chats powered by Groq’s API · Built with React, Vite, and Tailwind CSS
+            Fast chats powered by Groq’s API · Built with React, Vite, and Tailwind CSS ⚡️
           </div>
         </div>
       </footer>

--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -101,7 +101,7 @@ export default function AppShell({ children }) {
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 sm:justify-start">
             <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 sm:justify-start">
               <span className="font-semibold text-slate-700 dark:text-slate-200">Groq AllIn Studio</span>
-              <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Playground</span>
+              <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Unified Workspace</span>
             </div>
             <NavLink to="/" className={footerLinkClasses} end>Overview</NavLink>
             <NavLink to="/about" className={footerLinkClasses}>About</NavLink>

--- a/all_in/src/pages/AboutPage.jsx
+++ b/all_in/src/pages/AboutPage.jsx
@@ -6,12 +6,12 @@ export default function AboutPage() {
       <section className="rounded-3xl bg-gradient-to-br from-slate-900 via-brand-700 to-indigo-600 px-8 py-12 text-white shadow-xl">
         <div className="max-w-3xl space-y-4">
           <p className="text-sm uppercase tracking-[0.3em] text-white/70">About Groq AllIn Studio</p>
-          <h1 className="text-3xl font-semibold sm:text-4xl">Louis Paulet&apos;s Groq AllIn Studio</h1>
+          <h1 className="text-3xl font-semibold sm:text-4xl">Louis Paulet&apos;s Groq AllIn Studio 🤝</h1>
           <p className="text-base text-white/90">
             Groq AllIn Studio is a personal initiative by Louis Paulet, Data Scientist at Checkout.com. The project explores
             how GroqCloud services can support focused conversational tools while complementing his production work. Each
             module tests practical applications, latency-sensitive interfaces, and the supporting infrastructure required to
-            run them responsibly.
+            run them responsibly. 🔍
           </p>
           <Link
             to="/"
@@ -24,24 +24,24 @@ export default function AboutPage() {
 
       <section className="grid gap-8 md:grid-cols-3">
         <article className="space-y-3 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">1. Frontend studio</h2>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">1. Frontend studio 🖥️</h2>
           <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            The <code>all_in/</code> workspace is the production React shell that unifies the Pokédex, AllergyFinder, STL Viewer,
+            🧱 The <code>all_in/</code> workspace is the production React shell that unifies the Pokédex, AllergyFinder, STL Viewer,
             and Object Maker experiences for deployment. It is the only project that ships live, while reusing shared chat and UI
             components across each tab.
           </p>
         </article>
         <article className="space-y-3 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">2. Cloudflare worker backend</h2>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">2. Cloudflare worker backend ☁️</h2>
           <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            A dedicated Cloudflare Worker powers the Groq backend. Every chat in the studio tunnels through this worker, which
+            ☁️ A dedicated Cloudflare Worker powers the Groq backend. Every chat in the studio tunnels through this worker, which
             enriches prompts with tools like OpenFoodFacts lookups before relaying Groq responses.
           </p>
         </article>
         <article className="space-y-3 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">3. Applied research space</h2>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">3. Applied research space 🧪</h2>
           <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            The studio hosts a rotating set of exploratory prompts and prototypes that examine new interaction patterns. It is
+            🔬 The studio hosts a rotating set of exploratory prompts and prototypes that examine new interaction patterns. It is
             the venue for trying emerging Groq capabilities, refining responsible guardrails, and translating lessons back into
             production-quality solutions.
           </p>
@@ -49,39 +49,39 @@ export default function AboutPage() {
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Why the worker matters</h2>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Why the worker matters 🛠️</h2>
         <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
           Louis designed the worker to carry its own intelligence. Beyond proxying Groq models, it can query product data when a
           chat session asks about allergens, providing the same OpenFoodFacts evidence that powers the dedicated AllergyFinder
-          experience.
+          experience. 🧠
         </p>
         <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
           The Object Maker tooling leans on the worker too: schema brainstorming happens through the chat endpoint, then the
-          structured output endpoint turns those schemas into real JSON objects.
+          structured output endpoint turns those schemas into real JSON objects. 🧾
         </p>
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Supported worker routes</h2>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Supported worker routes 🚦</h2>
         <ul className="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-400">
           <li>
             <span className="font-semibold text-slate-800 dark:text-slate-200">POST /chat</span> — primary endpoint used by every
             experience. The frontend appends <code>/chat</code> to the configured base URL and sends OpenAI-style chat payloads;
-            the worker can augment requests with product lookups before returning Groq responses.
+            the worker can augment requests with product lookups before returning Groq responses. 💬
           </li>
           <li>
             <span className="font-semibold text-slate-800 dark:text-slate-200">GET /flavor-finder/&lt;food&gt;</span> — helper route
             that fetches OpenFoodFacts entries directly, useful for debugging the worker&apos;s ingredient sourcing without spinning
-            up the UI.
+            up the UI. 🔎
           </li>
           <li>
             <span className="font-semibold text-slate-800 dark:text-slate-200">POST /obj/&lt;type&gt; (and /object*/ variants)</span> —
             structured generation endpoint consumed by Object Maker. It accepts a JSON schema, user prompt, and optional model
-            parameters, then returns a compliant object.
+            parameters, then returns a compliant object. 🧩
           </li>
         </ul>
         <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          The worker keeps each experiment consistent, ensuring the studio remains reliable even as new ideas are introduced.
+          The worker keeps each experiment consistent, ensuring the studio remains reliable even as new ideas are introduced. 📈
         </p>
       </section>
     </div>

--- a/all_in/src/pages/AboutPage.jsx
+++ b/all_in/src/pages/AboutPage.jsx
@@ -6,11 +6,12 @@ export default function AboutPage() {
       <section className="rounded-3xl bg-gradient-to-br from-slate-900 via-brand-700 to-indigo-600 px-8 py-12 text-white shadow-xl">
         <div className="max-w-3xl space-y-4">
           <p className="text-sm uppercase tracking-[0.3em] text-white/70">About Groq AllIn Studio</p>
-          <h1 className="text-3xl font-semibold sm:text-4xl">Louis Paulet&apos;s Groq playground 🚀</h1>
+          <h1 className="text-3xl font-semibold sm:text-4xl">Louis Paulet&apos;s Groq AllIn Studio</h1>
           <p className="text-base text-white/90">
-            Groq AllIn Studio is a side project by Louis Paulet, Data Scientist at Checkout.com, built to stretch the GroqCloud
-            free tier and explore how far a single worker-backed chat experience can go. It is also his playground for doing
-            delightfully impractical LLM experiments when he feels like using models for mischief instead of meetings. 😎
+            Groq AllIn Studio is a personal initiative by Louis Paulet, Data Scientist at Checkout.com. The project explores
+            how GroqCloud services can support focused conversational tools while complementing his production work. Each
+            module tests practical applications, latency-sensitive interfaces, and the supporting infrastructure required to
+            run them responsibly.
           </p>
           <Link
             to="/"
@@ -38,11 +39,11 @@ export default function AboutPage() {
           </p>
         </article>
         <article className="space-y-3 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">3. LLMs for fun 🎉</h2>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">3. Applied research space</h2>
           <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            Louis keeps a rotating carousel of playful prompts and half-serious experiments stitched into the studio. When the
-            day job runs on production-grade guardrails, this space is free to chase goofy generative ideas, remix agent flows,
-            and generally see what Groq silicon can do when the stakes are just vibes.
+            The studio hosts a rotating set of exploratory prompts and prototypes that examine new interaction patterns. It is
+            the venue for trying emerging Groq capabilities, refining responsible guardrails, and translating lessons back into
+            production-quality solutions.
           </p>
         </article>
       </section>
@@ -80,8 +81,7 @@ export default function AboutPage() {
           </li>
         </ul>
         <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          The worker is the glue that keeps every playful detour coherent inside Groq AllIn Studio, even when the brief is simply
-          “let&apos;s see what happens.” 🤖
+          The worker keeps each experiment consistent, ensuring the studio remains reliable even as new ideas are introduced.
         </p>
       </section>
     </div>

--- a/all_in/src/pages/HomePage.jsx
+++ b/all_in/src/pages/HomePage.jsx
@@ -5,59 +5,59 @@ const detailedCopyById = {
   allergyfinder: (
     <>
       <p>
-        AllergyFinder taps into Open Food Facts so it can examine ingredient panels in context. Bring your saved allergen
+        🛡️ AllergyFinder taps into Open Food Facts so it can examine ingredient panels in context. Bring your saved allergen
         profile into the conversation and the assistant highlights risky ingredients, suggests safe alternatives, and drafts
         grocery lists that respect your preferences. Transparency comes first: responses call out when product data is
-        missing or when you should double-check real-world packaging.
+        missing or when you should double-check real-world packaging. 🧾
       </p>
       <p>
         Use it for meal planning, quick label triage, or inspiration when you are cooking for friends with different dietary
-        needs. Because it runs on Groq-accelerated LLMs, you get near-instant summaries even for lengthy ingredient lists.
+        needs. Because it runs on Groq-accelerated LLMs, you get near-instant summaries even for lengthy ingredient lists. 🚀
       </p>
     </>
   ),
   objectmaker: (
     <>
       <p>
-        Object Maker is a workspace for structured creativity. Start with a conversational brief and the assistant drafts JSON
+        🧠 Object Maker is a workspace for structured creativity. Start with a conversational brief and the assistant drafts JSON
         schemas that describe imaginative artifacts—anything from a pizza, to a track-ready car, to a curated ice cream
         flight. Once the schema looks right, you can call the
         <code className="rounded bg-slate-900/80 px-1 py-0.5 text-[0.7rem] text-white">/obj</code> endpoint to spin up
         dozens of variants that adhere to the structure. The workflow is grounded in Groq hosted
         <span className="font-medium"> openai/gpt-oss-20b</span> and <span className="font-medium">openai/gpt-oss-120b</span>
-        models, keeping generation fast while your schema evolves.
+        models, keeping generation fast while your schema evolves. ⚙️
       </p>
       <p>
         Each session curates a “Zoo” of finished creations so you can revisit, iterate, and compare outputs. The aim is to
         demonstrate how reliable JSON scaffolding unlocks downstream tooling: the sharper the schema, the more dependable the
-        generated objects. Image generation integrations are planned, but today is about perfecting the structured prompt.
+        generated objects. Image generation integrations are planned, but today is about perfecting the structured prompt. 🗂️
       </p>
     </>
   ),
   stlviewer: (
     <>
       <p>
-        STL Studio preserves the original 3D printing workflow. The assistant can draft STL snippets, explain mesh edits, and,
+        🧩 STL Studio preserves the original 3D printing workflow. The assistant can draft STL snippets, explain mesh edits, and,
         thanks to the embedded viewer, render models directly inside the chat transcript. Share a design tweak, paste an STL
-        file, and see the preview update without leaving the conversation.
+        file, and see the preview update without leaving the conversation. 🖥️
       </p>
       <p>
         It is ideal for rapid iteration on printable parts, offering slicing tips, material suggestions, and context-aware
         troubleshooting. Whether you are validating overhangs or collaborating on a new gadget, the mix of text guidance and
-        inline visuals keeps the feedback loop tight.
+        inline visuals keeps the feedback loop tight. 🔁
       </p>
     </>
   ),
   pokedex: (
     <>
       <p>
-        The Pokédex workspace is a focused encyclopedia for trainers. Ask about any Pokémon and you will get typings,
+        📘 The Pokédex workspace is a focused encyclopedia for trainers. Ask about any Pokémon and you will get typings,
         strengths, weaknesses, and a bite-sized lore blurb sourced from our remote service. It is tuned to stay in-universe:
-        off-topic questions politely steer you back to the Pokédex.
+        off-topic questions politely steer you back to the Pokédex. 🎓
       </p>
       <p>
         Combine it with team-building sessions or quick reminders before a battle. Because the base URL is configurable, you
-        can point the workspace at experimental datasets or community-maintained entries while keeping the same interface.
+        can point the workspace at experimental datasets or community-maintained entries while keeping the same interface. 🔄
       </p>
     </>
   ),
@@ -70,10 +70,10 @@ export default function HomePage() {
       <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-brand-600 to-indigo-700 px-8 py-12 text-white shadow-xl">
         <div className="max-w-3xl space-y-4">
           <p className="text-sm uppercase tracking-[0.3em] text-white/80">Groq Studio</p>
-          <h1 className="text-3xl font-semibold sm:text-4xl">All experiences in one workspace.</h1>
+          <h1 className="text-3xl font-semibold sm:text-4xl">All experiences in one workspace. 💼</h1>
           <p className="text-base text-white/90">
             Explore specialized assistants for nutrition, 3D printing, and Pokémon knowledge with a shared interface and a
-            streamlined workflow.
+            streamlined workflow. ⚡️
           </p>
           <div className="flex flex-wrap gap-3 pt-2">
             {experiences.map((experience) => (
@@ -92,10 +92,10 @@ export default function HomePage() {
 
       <section className="space-y-10">
         <header className="space-y-2">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Explore the workspaces</h2>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Explore the workspaces ✨</h2>
           <p className="text-sm text-slate-600 dark:text-slate-400">
             Each experience shares the same chat shell yet brings its own data sources, inline tools, and best practices. Dive in to
-            see how focused assistants feel when they are tuned for a specific workflow.
+            see how focused assistants feel when they are tuned for a specific workflow. 🎯
           </p>
         </header>
         <div className="space-y-8">

--- a/all_in/src/pages/HomePage.jsx
+++ b/all_in/src/pages/HomePage.jsx
@@ -19,8 +19,8 @@ const detailedCopyById = {
   objectmaker: (
     <>
       <p>
-        Object Maker is our playground for structured creativity. Start with a conversational brief and the assistant drafts
-        JSON schemas that describe imaginative artifacts—anything from a pizza, to a track-ready car, to a whimsical ice cream
+        Object Maker is a workspace for structured creativity. Start with a conversational brief and the assistant drafts JSON
+        schemas that describe imaginative artifacts—anything from a pizza, to a track-ready car, to a curated ice cream
         flight. Once the schema looks right, you can call the
         <code className="rounded bg-slate-900/80 px-1 py-0.5 text-[0.7rem] text-white">/obj</code> endpoint to spin up
         dozens of variants that adhere to the structure. The workflow is grounded in Groq hosted
@@ -28,18 +28,18 @@ const detailedCopyById = {
         models, keeping generation fast while your schema evolves.
       </p>
       <p>
-        Every session also curates a “Zoo” of finished creations so you can revisit, remix, and compare outputs. The goal is to
-        explore how reliable JSON scaffolding unlocks downstream tooling: the tighter the schema, the more adventurous the
-        generated objects. Image generation hooks are on the roadmap, but today is all about perfecting the structured prompt.
+        Each session curates a “Zoo” of finished creations so you can revisit, iterate, and compare outputs. The aim is to
+        demonstrate how reliable JSON scaffolding unlocks downstream tooling: the sharper the schema, the more dependable the
+        generated objects. Image generation integrations are planned, but today is about perfecting the structured prompt.
       </p>
     </>
   ),
   stlviewer: (
     <>
       <p>
-        STL Studio keeps the original 3D printing experiment alive. The assistant can draft STL snippets, explain mesh edits,
-        and, thanks to the embedded viewer, render models directly inside the chat transcript. Share a design tweak, paste an
-        STL file, and see the preview update without leaving the conversation.
+        STL Studio preserves the original 3D printing workflow. The assistant can draft STL snippets, explain mesh edits, and,
+        thanks to the embedded viewer, render models directly inside the chat transcript. Share a design tweak, paste an STL
+        file, and see the preview update without leaving the conversation.
       </p>
       <p>
         It is ideal for rapid iteration on printable parts, offering slicing tips, material suggestions, and context-aware
@@ -69,10 +69,11 @@ export default function HomePage() {
     <div className="space-y-12">
       <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-brand-600 to-indigo-700 px-8 py-12 text-white shadow-xl">
         <div className="max-w-3xl space-y-4">
-          <p className="text-sm uppercase tracking-[0.3em] text-white/80">Groq Playground</p>
-          <h1 className="text-3xl font-semibold sm:text-4xl">All experiences under one roof.</h1>
+          <p className="text-sm uppercase tracking-[0.3em] text-white/80">Groq Studio</p>
+          <h1 className="text-3xl font-semibold sm:text-4xl">All experiences in one workspace.</h1>
           <p className="text-base text-white/90">
-            Explore specialized assistants for nutrition, 3D printing, and Pokemon knowledge with a unified design and faster workflow.
+            Explore specialized assistants for nutrition, 3D printing, and Pokémon knowledge with a shared interface and a
+            streamlined workflow.
           </p>
           <div className="flex flex-wrap gap-3 pt-2">
             {experiences.map((experience) => (

--- a/all_in/src/pages/ObjectMakerZoo.jsx
+++ b/all_in/src/pages/ObjectMakerZoo.jsx
@@ -81,7 +81,7 @@ export default function ObjectMakerZoo() {
               onClick={handleClearAll}
               className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
             >
-              Clear Zoo
+              Delete all saved objects
             </button>
           ) : null}
         </div>
@@ -89,7 +89,7 @@ export default function ObjectMakerZoo() {
 
       {entries.length === 0 ? (
         <div className="rounded-xl border border-slate-200 bg-white/70 p-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-400">
-          No entries yet. Create objects in the Builder, and they will appear here grouped by type.
+          No entries yet. Create objects in the Builder and they will appear here grouped by type.
         </div>
       ) : null}
 

--- a/all_in/src/pages/ObjectMakerZoo.jsx
+++ b/all_in/src/pages/ObjectMakerZoo.jsx
@@ -73,15 +73,15 @@ export default function ObjectMakerZoo() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">Object Zoo</h3>
+        <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">Object Zoo 🦾</h3>
         <div className="flex items-center gap-2">
-          <Link to="/objectmaker" className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/60">Back to Builder</Link>
+          <Link to="/objectmaker" className="rounded-md border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/60">Back to Builder 🛠️</Link>
           {entries.length > 0 ? (
             <button
               onClick={handleClearAll}
               className="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
             >
-              Delete all saved objects
+              Delete all saved objects 🧹
             </button>
           ) : null}
         </div>
@@ -89,14 +89,14 @@ export default function ObjectMakerZoo() {
 
       {entries.length === 0 ? (
         <div className="rounded-xl border border-slate-200 bg-white/70 p-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-400">
-          No entries yet. Create objects in the Builder and they will appear here grouped by type.
+          No entries yet. Create objects in the Builder and they will appear here grouped by type. 📝
         </div>
       ) : null}
 
       {[...grouped.entries()].map(([type, list]) => (
         <section key={type} className="space-y-3">
           <div className="flex items-center justify-between">
-            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{type} — {list.length}</h4>
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">{type} — {list.length} 📦</h4>
           </div>
           <div className="grid gap-3 md:grid-cols-2">
             {list.map((entry) => (


### PR DESCRIPTION
## Summary
- refresh the About and Home pages with professional language that better reflects Groq AllIn Studio’s goals
- clarify messaging in the chat sidebar, Object Maker Zoo, STL previews, and footer to use consistent terminology
- tighten Profile and Allergy Cookie copy so guidance on cookies and saved data is clear to prospective viewers

## Testing
- npm run build *(fails: Vite/Rollup cannot resolve @zxing/browser during build)*

------
https://chatgpt.com/codex/tasks/task_e_68e196142af88320b78a5b845e5fd1fa