### PR TITLE
Embed Flavor Finder barcode context in AllergyFinder

### DIFF
--- a/all_in/src/lib/flavorFinder.js
+++ b/all_in/src/lib/flavorFinder.js
@@ -1,0 +1,163 @@
+const OPEN_FOOD_FACTS_URL_PATTERN = /openfoodfacts\.org\/(?:[a-z]{2}\/)?produit\/(\d{6,})/gi
+const BARE_CODE_PATTERN = /\b(\d{8,18})\b/g
+
+function extractOpenFoodFactsCode(input) {
+  if (!input) return null
+  const text = String(input)
+
+  OPEN_FOOD_FACTS_URL_PATTERN.lastIndex = 0
+  let urlMatch
+  while ((urlMatch = OPEN_FOOD_FACTS_URL_PATTERN.exec(text))) {
+    const code = urlMatch[1]
+    if (code) {
+      return code
+    }
+  }
+
+  const compact = text.replace(/[^0-9]/g, '')
+  const nonBarcodeCharacters = text.replace(/[0-9\s-]/g, '')
+  if (compact.length >= 8 && compact.length <= 18 && !nonBarcodeCharacters) {
+    return compact
+  }
+
+  BARE_CODE_PATTERN.lastIndex = 0
+  const bareMatch = BARE_CODE_PATTERN.exec(text)
+  if (bareMatch && bareMatch[1]) {
+    return bareMatch[1]
+  }
+
+  return null
+}
+
+async function fetchFlavorFinderProduct(baseUrl, code, { signal } = {}) {
+  const trimmedBase = typeof baseUrl === 'string' ? baseUrl.trim().replace(/\/$/, '') : ''
+  if (!trimmedBase || !code) return null
+  const url = `${trimmedBase}/flavor-finder/${encodeURIComponent(code)}`
+
+  let response
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal,
+    })
+  } catch (error) {
+    const wrapped = new Error(`Flavor Finder request failed: ${error?.message || error}`)
+    wrapped.cause = error
+    throw wrapped
+  }
+
+  const text = await response.text()
+  let payload
+  try {
+    payload = JSON.parse(text)
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const error = new Error(`Flavor Finder returned ${response.status}`)
+    error.status = response.status
+    error.body = text
+    throw error
+  }
+
+  return payload || null
+}
+
+function coerceValue(value) {
+  if (value === undefined || value === null) return ''
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (item === undefined || item === null) return ''
+        if (typeof item === 'string') return item.trim()
+        if (typeof item === 'number' || typeof item === 'boolean') return String(item)
+        return ''
+      })
+      .filter(Boolean)
+      .join(', ')
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (typeof value === 'string') {
+    return value.trim()
+  }
+  return ''
+}
+
+function addDetail(details, label, value) {
+  const coerced = coerceValue(value)
+  if (!coerced) return
+  details.push(`${label}: ${coerced}`)
+}
+
+function formatFlavorFinderContext(code, payload) {
+  const products = Array.isArray(payload?.products) ? payload.products : []
+  if (!code || products.length === 0) return null
+
+  const lines = [`OpenFoodFacts product context for barcode ${code}:`]
+
+  const resolvedUrl = coerceValue(payload?.resolvedUrl)
+  if (resolvedUrl) {
+    lines.push(`Resolved URL: ${resolvedUrl}`)
+  }
+
+  const resolvedSlug = coerceValue(payload?.resolvedSlug)
+  if (resolvedSlug) {
+    lines.push(`Resolved slug: ${resolvedSlug}`)
+  }
+
+  const sources = coerceValue(payload?.sources)
+  if (sources) {
+    lines.push(`Sources: ${sources}`)
+  }
+
+  const maxProducts = 3
+  products.slice(0, maxProducts).forEach((product, index) => {
+    const name = coerceValue(
+      product?.name || product?.genericName || product?.generic_name || product?.product_name,
+    ) || `Product ${index + 1}`
+    const header = `Product ${index + 1}: ${name}`
+    lines.push(header)
+
+    const details = []
+    addDetail(details, 'Brands', product?.brands)
+    addDetail(details, 'Quantity', product?.quantity)
+    addDetail(details, 'Serving size', product?.servingSize || product?.serving_size)
+    addDetail(details, 'Nutri-Score', product?.nutriscore || product?.nutrition_grade)
+    addDetail(details, 'NOVA group', product?.nova)
+    addDetail(details, 'Labels', product?.labels)
+    addDetail(details, 'Categories', product?.categories)
+    addDetail(details, 'Ingredients', product?.ingredients)
+    addDetail(details, 'Allergens', product?.allergens)
+    addDetail(details, 'Traces', product?.traces)
+    addDetail(details, 'Additives', product?.additives)
+    addDetail(details, 'Ingredients analysis', product?.ingredientsAnalysis || product?.ingredients_analysis)
+
+    if (details.length > 0) {
+      details.forEach((detail) => {
+        lines.push(`  - ${detail}`)
+      })
+    }
+  })
+
+  if (products.length > maxProducts) {
+    lines.push(`(+ ${products.length - maxProducts} additional products omitted)`)
+  }
+
+  return lines.join('\n')
+}
+
+async function buildFlavorFinderContext(baseUrl, text, { signal } = {}) {
+  const code = extractOpenFoodFactsCode(text)
+  if (!code) return null
+  const payload = await fetchFlavorFinderProduct(baseUrl, code, { signal })
+  if (!payload) return null
+  const summary = formatFlavorFinderContext(code, payload)
+  if (!summary) return null
+  return { code, summary, payload }
+}
+
+export { buildFlavorFinderContext, extractOpenFoodFactsCode, fetchFlavorFinderProduct, formatFlavorFinderContext }

--- a/demos/test_flavor_finder_barcode.html
+++ b/demos/test_flavor_finder_barcode.html
@@ -111,10 +111,10 @@
     </style>
   </head>
   <body>
-    <h1>Flavor Finder – Barcode Resolver</h1>
+    <h1>Flavor Finder – Barcode Lookup</h1>
     <p>
-      Paste a barcode or Open Food Facts product ID to confirm the worker follows redirects and returns the
-      final product slug.
+      Paste a barcode or Open Food Facts product ID to fetch the product details returned by the Flavor Finder
+      API. This mirrors what the AllergyFinder chat experience now embeds when a barcode is detected.
     </p>
 
     <label for="endpoint">Endpoint</label>
@@ -131,7 +131,7 @@
     <label for="productId">Product ID or barcode</label>
     <input type="text" id="productId" placeholder="e.g. 3350033995093" />
 
-    <button id="runButton">Resolve product</button>
+    <button id="runButton">Fetch product context</button>
 
     <div class="status" id="status">(waiting for input)</div>
 
@@ -150,10 +150,20 @@
       <dl>
         <dt>Status</dt>
         <dd id="responseStatus" class="empty">(none yet)</dd>
-        <dt>Resolved URL</dt>
-        <dd id="resolvedUrl" class="empty">(none yet)</dd>
-        <dt>Resolved Slug</dt>
-        <dd id="resolvedSlug" class="empty">(none yet)</dd>
+        <dt>Product name</dt>
+        <dd id="productName" class="empty">(none yet)</dd>
+        <dt>Brands</dt>
+        <dd id="productBrands" class="empty">(none yet)</dd>
+        <dt>Nutri-Score</dt>
+        <dd id="productNutriscore" class="empty">(none yet)</dd>
+        <dt>Quantity</dt>
+        <dd id="productQuantity" class="empty">(none yet)</dd>
+        <dt>Ingredients</dt>
+        <dd id="productIngredients" class="empty">(none yet)</dd>
+        <dt>Allergens</dt>
+        <dd id="productAllergens" class="empty">(none yet)</dd>
+        <dt>Traces</dt>
+        <dd id="productTraces" class="empty">(none yet)</dd>
         <dt>Products returned</dt>
         <dd id="productCount" class="empty">(none yet)</dd>
         <dt>Sources</dt>
@@ -174,24 +184,46 @@
       const statusDiv = document.getElementById('status');
       const requestUrlDd = document.getElementById('requestUrl');
       const responseStatusDd = document.getElementById('responseStatus');
-      const resolvedUrlDd = document.getElementById('resolvedUrl');
-      const resolvedSlugDd = document.getElementById('resolvedSlug');
+      const productNameDd = document.getElementById('productName');
+      const productBrandsDd = document.getElementById('productBrands');
+      const productNutriscoreDd = document.getElementById('productNutriscore');
+      const productQuantityDd = document.getElementById('productQuantity');
+      const productIngredientsDd = document.getElementById('productIngredients');
+      const productAllergensDd = document.getElementById('productAllergens');
+      const productTracesDd = document.getElementById('productTraces');
       const productCountDd = document.getElementById('productCount');
       const sourcesDd = document.getElementById('sources');
       const responseJsonPre = document.getElementById('responseJson');
 
       function resetSummary() {
-        responseStatusDd.textContent = '(none yet)';
-        responseStatusDd.classList.add('empty');
-        resolvedUrlDd.textContent = '(none yet)';
-        resolvedUrlDd.classList.add('empty');
-        resolvedSlugDd.textContent = '(none yet)';
-        resolvedSlugDd.classList.add('empty');
-        productCountDd.textContent = '(none yet)';
-        productCountDd.classList.add('empty');
-        sourcesDd.textContent = '(none yet)';
-        sourcesDd.classList.add('empty');
+        const resetToEmpty = (element) => {
+          element.textContent = '(none yet)';
+          element.classList.add('empty');
+        };
+
+        resetToEmpty(responseStatusDd);
+        resetToEmpty(productNameDd);
+        resetToEmpty(productBrandsDd);
+        resetToEmpty(productNutriscoreDd);
+        resetToEmpty(productQuantityDd);
+        resetToEmpty(productIngredientsDd);
+        resetToEmpty(productAllergensDd);
+        resetToEmpty(productTracesDd);
+        resetToEmpty(productCountDd);
+        resetToEmpty(sourcesDd);
         responseJsonPre.textContent = '(no response yet)';
+      }
+
+      function fillSummaryField(element, value) {
+        if (!element) return;
+        const hasValue = value !== undefined && value !== null && String(value).trim() !== '';
+        if (hasValue) {
+          element.textContent = String(value);
+          element.classList.remove('empty');
+        } else {
+          element.textContent = '(not provided)';
+          element.classList.add('empty');
+        }
       }
 
       function getBaseEndpoint() {
@@ -236,7 +268,10 @@
         responseJsonPre.textContent = '(waiting for response...)';
 
         try {
-          const res = await fetch(url, { method: 'GET' });
+          const res = await fetch(url, {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+          });
           const text = await res.text();
           responseStatusDd.textContent = String(res.status);
           responseStatusDd.classList.remove('empty');
@@ -249,28 +284,33 @@
             responseJsonPre.textContent = text;
           }
 
-          if (parsed && typeof parsed === 'object') {
-            const resolvedUrl = parsed.resolvedUrl || (parsed.products?.[0]?.source ?? '');
-            if (resolvedUrl) {
-              resolvedUrlDd.textContent = resolvedUrl;
-              resolvedUrlDd.classList.remove('empty');
-            }
+          const products = Array.isArray(parsed?.products) ? parsed.products : [];
+          const firstProduct = products[0] || {};
 
-            const resolvedSlug = parsed.resolvedSlug || parsed.products?.[0]?.slug || '';
-            if (resolvedSlug) {
-              resolvedSlugDd.textContent = resolvedSlug;
-              resolvedSlugDd.classList.remove('empty');
-            }
+          const safeValue = (value) => {
+            if (!value) return '';
+            return String(value);
+          };
 
-            const count = Array.isArray(parsed.products) ? parsed.products.length : 0;
-            productCountDd.textContent = String(count);
-            productCountDd.classList.remove('empty');
+          const summaryEntries = [
+            [productNameDd, safeValue(firstProduct.name || firstProduct.genericName || firstProduct.generic_name)],
+            [productBrandsDd, safeValue(firstProduct.brands)],
+            [productNutriscoreDd, safeValue(firstProduct.nutriscore || firstProduct.nutrition_grade)],
+            [productQuantityDd, safeValue(firstProduct.quantity)],
+            [productIngredientsDd, safeValue(firstProduct.ingredients)],
+            [productAllergensDd, safeValue(firstProduct.allergens)],
+            [productTracesDd, safeValue(firstProduct.traces)],
+          ];
 
-            if (Array.isArray(parsed.sources) && parsed.sources.length > 0) {
-              sourcesDd.textContent = parsed.sources.join(', ');
-              sourcesDd.classList.remove('empty');
-            }
-          }
+          summaryEntries.forEach(([element, value]) => fillSummaryField(element, value));
+
+          const count = products.length;
+          fillSummaryField(productCountDd, String(count));
+
+          const sources = Array.isArray(parsed?.sources) && parsed.sources.length > 0
+            ? parsed.sources.join(', ')
+            : '';
+          fillSummaryField(sourcesDd, sources);
 
           statusDiv.textContent = 'Request completed.';
         } catch (error) {


### PR DESCRIPTION
## Summary
- add a Flavor Finder helper to normalize barcodes, fetch product data, and format context strings
- augment the AllergyFinder chat flow to append Flavor Finder product context when a barcode or OpenFoodFacts code is provided
- refresh the barcode demo to surface product metadata returned by the updated API response

## Testing
- npm run lint --prefix all_in

------
https://chatgpt.com/codex/tasks/task_e_68e1a76b517c8320b0e8a878475bf110