### PR TITLE
Add sentiment classification to news analyzer

### DIFF
--- a/all_in/src/components/newsanalyzer/NewsAnalyzerNav.jsx
+++ b/all_in/src/components/newsanalyzer/NewsAnalyzerNav.jsx
@@ -1,7 +1,32 @@
-export default function NewsAnalyzerNav() {
+const FILTER_OPTIONS = [
+  { value: 'all', label: 'All news' },
+  { value: 'good', label: 'Good only' },
+  { value: 'bad', label: 'Bad only' },
+];
+
+export default function NewsAnalyzerNav({ filter, onFilterChange }) {
   return (
-    <div className="p-4">
+    <div className="flex flex-col gap-3 p-4">
       <h2 className="text-lg font-semibold">News Headlines by Category</h2>
+      <div className="flex flex-wrap gap-2">
+        {FILTER_OPTIONS.map((option) => {
+          const isActive = filter === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onFilterChange(option.value)}
+              className={`rounded-full border px-3 py-1 text-sm transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
+                isActive
+                  ? 'border-blue-500 bg-blue-500 text-white shadow-sm focus-visible:ring-blue-500'
+                  : 'border-slate-300 bg-white text-slate-600 hover:border-blue-400 hover:text-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-blue-400'
+              }`}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
-  )
+  );
 }

--- a/all_in/src/components/newsanalyzer/NewsAnalyzerView.jsx
+++ b/all_in/src/components/newsanalyzer/NewsAnalyzerView.jsx
@@ -1,58 +1,104 @@
-const CATEGORY_LABELS = {
-  top: 'Top Stories',
-  world: 'World',
-  us: 'US',
-  business: 'Business',
-  technology: 'Technology',
-  politics: 'Politics',
-  health: 'Health',
-  entertainment: 'Entertainment',
-  travel: 'Travel',
-  all: 'Everything',
-};
+import { CATEGORY_LABELS, CATEGORY_ORDER } from './constants';
 
-export default function NewsAnalyzerView({ news, loading }) {
+function articleMatchesFilter(filter, classification) {
+  if (filter === 'all') return true;
+  if (!classification || !classification.sentiment) return false;
+  return classification.sentiment === filter;
+}
+
+function getSentimentStyles(sentiment) {
+  if (sentiment === 'good') {
+    return 'bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-500/40';
+  }
+  if (sentiment === 'bad') {
+    return 'bg-rose-50 dark:bg-rose-900/30 border border-rose-200 dark:border-rose-500/40';
+  }
+  return 'bg-white dark:bg-slate-800 border border-transparent';
+}
+
+export default function NewsAnalyzerView({ news, loading, classifications, filter }) {
   if (loading) {
     return <div className="p-4 text-center">Loading news...</div>;
   }
 
   return (
     <div className="space-y-16">
-      {Object.entries(news).map(([category, items]) => (
-        <section key={category}>
-          <div className="relative mb-8">
-            <div className="absolute inset-0 flex items-center" aria-hidden="true">
-              <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
+      {CATEGORY_ORDER.map((category) => {
+        const items = (news[category] || []).slice(0, 5);
+        if (!items.length) return null;
+
+        return (
+          <section key={category}>
+            <div className="relative mb-8">
+              <div className="absolute inset-0 flex items-center" aria-hidden="true">
+                <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
+              </div>
+              <div className="relative flex justify-center">
+                <span className="bg-white dark:bg-slate-900 px-4 text-2xl font-serif text-gray-500 dark:text-gray-400">{CATEGORY_LABELS[category]}</span>
+              </div>
             </div>
-            <div className="relative flex justify-center">
-              <span className="bg-white dark:bg-slate-900 px-4 text-2xl font-serif text-gray-500 dark:text-gray-400">{CATEGORY_LABELS[category]}</span>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {items.map((item, index) => {
+                const key = `${category}-${index}`;
+                const classification = classifications?.[key];
+                if (!articleMatchesFilter(filter, classification)) return null;
+                const sentimentClass = getSentimentStyles(classification?.sentiment);
+
+                return (
+                  <article
+                    key={index}
+                    className={`rounded-lg shadow-lg overflow-hidden transform hover:-translate-y-1 transition-transform duration-300 ${sentimentClass}`}
+                  >
+                    <div className="p-6">
+                      <a
+                        href={item.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-2xl font-serif text-gray-800 dark:text-slate-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300"
+                      >
+                        {item.title.replace(/Fixture:/g, '')}
+                      </a>
+                      <div className="mt-3 text-sm text-gray-500 dark:text-slate-400">
+                        {new Date(item.publishedAt).toLocaleString()} • {item.sourceTitle}
+                      </div>
+                      <div className="mt-3 flex items-center gap-2 text-sm">
+                        <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 dark:bg-slate-700 dark:text-slate-200">
+                          {classification?.sentiment
+                            ? `${classification.sentiment} news`
+                            : classification?.status === 'pending'
+                              ? 'classifying…'
+                              : 'not classified'}
+                        </span>
+                        {classification?.status === 'error' && (
+                          <span className="text-xs text-rose-500">Classification failed</span>
+                        )}
+                      </div>
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {item.sourceTitle && (
+                          <span className="badge bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 border-gray-200 dark:border-slate-600">
+                            {item.sourceTitle}
+                          </span>
+                        )}
+                        {item.link && (
+                          <span className="badge bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 border-gray-200 dark:border-slate-600">
+                            {new URL(item.link).hostname.replace(/^www\./, '')}
+                          </span>
+                        )}
+                      </div>
+                      {item.description && (
+                        <p
+                          className="mt-4 text-gray-600 dark:text-slate-300"
+                          dangerouslySetInnerHTML={{ __html: item.description }}
+                        ></p>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
             </div>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-            {items.map((item, index) => (
-              <article key={index} className="bg-white dark:bg-slate-800 rounded-lg shadow-lg overflow-hidden transform hover:-translate-y-1 transition-transform duration-300">
-                <div className="p-6">
-                  <a href={item.link} target="_blank" rel="noopener noreferrer" className="text-2xl font-serif text-gray-800 dark:text-slate-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
-                    {item.title.replace(/Fixture:/g, '')}
-                  </a>
-                  <div className="mt-3 text-sm text-gray-500 dark:text-slate-400">
-                    {new Date(item.publishedAt).toLocaleString()} • {item.sourceTitle}
-                  </div>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {item.sourceTitle && <span className="badge bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 border-gray-200 dark:border-slate-600">{item.sourceTitle}</span>}
-                    {item.link && (
-                      <span className="badge bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 border-gray-200 dark:border-slate-600">
-                        {new URL(item.link).hostname.replace(/^www\./, '')}
-                      </span>
-                    )}
-                  </div>
-                  {item.description && <p className="mt-4 text-gray-600 dark:text-slate-300" dangerouslySetInnerHTML={{ __html: item.description }}></p>}
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-      ))}
+          </section>
+        );
+      })}
     </div>
   );
 }

--- a/all_in/src/components/newsanalyzer/constants.js
+++ b/all_in/src/components/newsanalyzer/constants.js
@@ -1,0 +1,13 @@
+export const CATEGORY_LABELS = {
+  top: 'Top Stories',
+  world: 'World',
+  us: 'US',
+  business: 'Business',
+  technology: 'Technology',
+  politics: 'Politics',
+  health: 'Health',
+  entertainment: 'Entertainment',
+  travel: 'Travel',
+};
+
+export const CATEGORY_ORDER = Object.keys(CATEGORY_LABELS);

--- a/all_in/src/pages/NewsAnalyzerPage.jsx
+++ b/all_in/src/pages/NewsAnalyzerPage.jsx
@@ -1,55 +1,170 @@
 // Trigger rebuild
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getExperienceById } from '../config/experiences';
 import ExperiencePage from './ExperiencePage';
 import NewsAnalyzerNav from '../components/newsanalyzer/NewsAnalyzerNav';
 import NewsAnalyzerView from '../components/newsanalyzer/NewsAnalyzerView';
-
-const CATEGORY_LABELS = {
-  top: 'Top Stories',
-  world: 'World',
-  us: 'US',
-  business: 'Business',
-  technology: 'Technology',
-  politics: 'Politics',
-  health: 'Health',
-  entertainment: 'Entertainment',
-  travel: 'Travel',
-  all: 'Everything',
-};
+import { CATEGORY_ORDER } from '../components/newsanalyzer/constants';
+import { createRemoteObject } from '../lib/objectApi';
 
 const BASE_URL = 'https://groq-endpoint.louispaulet13.workers.dev/';
+const CLASSIFICATION_STRUCTURE = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    sentiment: {
+      type: 'string',
+      enum: ['good', 'bad'],
+    },
+  },
+  required: ['sentiment'],
+};
+
+function buildPrompt(item) {
+  const parts = [
+    'Please classify the following news article while adhering the schema:',
+    '',
+    `Title: ${item.title || 'N/A'}`,
+  ];
+  if (item.description) parts.push(`Description: ${item.description}`);
+  if (item.sourceTitle) parts.push(`Source: ${item.sourceTitle}`);
+  if (item.publishedAt) parts.push(`Published At: ${item.publishedAt}`);
+  if (item.content) parts.push(`Content: ${item.content}`);
+  return parts.join('\n');
+}
 
 export default function NewsAnalyzerPage() {
   const experience = getExperienceById('newsanalyzer');
   const [news, setNews] = useState({});
   const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('all');
+  const [classifications, setClassifications] = useState({});
+  const classificationsRef = useRef(classifications);
+  const classificationQueueRef = useRef([]);
+  const processingRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    classificationsRef.current = classifications;
+  }, [classifications]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const runNextClassification = useCallback(() => {
+    if (!isMountedRef.current) return;
+    if (processingRef.current) return;
+    const nextTask = classificationQueueRef.current.shift();
+    if (!nextTask) return;
+    processingRef.current = true;
+    const { category, index, item } = nextTask;
+    const key = `${category}-${index}`;
+
+    (async () => {
+      try {
+        const { payload } = await createRemoteObject({
+          structure: CLASSIFICATION_STRUCTURE,
+          prompt: buildPrompt(item),
+          objectType: 'news-sentiment',
+          strict: true,
+        });
+        const sentiment = typeof payload?.sentiment === 'string' ? payload.sentiment.toLowerCase() : null;
+        const normalized = sentiment === 'good' || sentiment === 'bad' ? sentiment : null;
+        if (isMountedRef.current) {
+          setClassifications((prev) => ({
+            ...prev,
+            [key]: {
+              sentiment: normalized,
+              status: normalized ? 'complete' : 'error',
+            },
+          }));
+        }
+      } catch (error) {
+        console.error('Failed to classify article', error);
+        if (isMountedRef.current) {
+          setClassifications((prev) => ({
+            ...prev,
+            [key]: {
+              sentiment: null,
+              status: 'error',
+              error: error?.message || 'Classification failed',
+            },
+          }));
+        }
+      } finally {
+        processingRef.current = false;
+        if (isMountedRef.current) {
+          setTimeout(runNextClassification, 0);
+        }
+      }
+    })();
+  }, []);
 
   useEffect(() => {
     const fetchAllNews = async () => {
       setLoading(true);
       const allNews = {};
-      for (const category in CATEGORY_LABELS) {
-        if (category === 'all') continue;
+      for (const category of CATEGORY_ORDER) {
         try {
           const url = `${BASE_URL}news/${category}`;
           const response = await fetch(url, { headers: { Accept: 'application/json' } });
           const payload = await response.json();
-          allNews[category] = payload.items || [];
+          allNews[category] = (payload.items || []).slice(0, 5);
         } catch (error) {
           console.error(`Failed to fetch news for category: ${category}`, error);
+          allNews[category] = [];
         }
       }
-      setNews(allNews);
-      setLoading(false);
+      classificationQueueRef.current = [];
+      processingRef.current = false;
+      if (isMountedRef.current) {
+        setClassifications({});
+        setNews(allNews);
+        setLoading(false);
+      }
     };
 
     fetchAllNews();
   }, []);
 
+  useEffect(() => {
+    if (!Object.keys(news).length) return;
+
+    const newTasks = [];
+    const pendingUpdates = {};
+
+    for (const category of CATEGORY_ORDER) {
+      const items = news[category] || [];
+      items.forEach((item, index) => {
+        const key = `${category}-${index}`;
+        if (!classificationsRef.current[key]) {
+          newTasks.push({ category, index, item });
+          pendingUpdates[key] = { sentiment: null, status: 'pending' };
+        }
+      });
+    }
+
+    if (!newTasks.length) return;
+
+    setClassifications((prev) => ({ ...prev, ...pendingUpdates }));
+    classificationQueueRef.current.push(...newTasks);
+    runNextClassification();
+  }, [news, runNextClassification]);
+
   return (
-    <ExperiencePage experience={experience} navigation={<NewsAnalyzerNav />}>
-      <NewsAnalyzerView news={news} loading={loading} />
+    <ExperiencePage
+      experience={experience}
+      navigation={<NewsAnalyzerNav filter={filter} onFilterChange={setFilter} />}
+    >
+      <NewsAnalyzerView
+        news={news}
+        loading={loading}
+        classifications={classifications}
+        filter={filter}
+      />
     </ExperiencePage>
   );
 }


### PR DESCRIPTION
## Summary
- classify fetched news articles through the /obj endpoint and queue results for sequential processing
- color articles by sentiment, add filtering controls, and limit each category to five stories
- centralize shared news category metadata for reuse across the page and view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a88928b88320a054ad2a510918b5