### PR TITLE
Ensure navbar labels stay on one line

### DIFF
--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -14,7 +14,7 @@ function ThemeToggle() {
       title="Toggle theme"
     >
       {dark ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
-      <span className="hidden sm:inline">{dark ? 'Light mode' : 'Dark mode'}</span>
+      <span className="hidden sm:inline">{dark ? 'Light mode' : 'Dark mode'}</span>
     </button>
   )
 }

--- a/all_in/src/config/experiences.js
+++ b/all_in/src/config/experiences.js
@@ -134,7 +134,7 @@ export const experiences = [
   {
     id: 'newsanalyzer',
     path: '/newsanalyzer',
-    name: 'News Analyzer',
+    name: 'News Analyzer',
     headline: 'Real-time News Analysis',
     description: 'Explore and analyze real-time news feeds from various sources, powered by a Cloudflare Worker.',
     badge: 'News',


### PR DESCRIPTION
## Summary
- ensure the News Analyzer nav item uses a non-breaking space so its label never wraps
- update the theme toggle label to keep the Dark/Light mode text together on a single line

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2d357d6ec8320908dfdaca37213e2