### PR TITLE
Remove legacy references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 ![Illustration banner showing the Groq AllIn Studio experiences](all_in/allin_illustration_banner.png)
 
-Groq AllIn Studio is the flagship experience in this repo: a single React workspace that bundles the Pokédex, AllergyFinder, STL viewer, and News Analyzer demos behind one shell. The live deployment is available at https://groq-allin.thefrenchartist.dev/. The legacy folders remain for focused local work, but only `all_in` is packaged for production.
+Groq AllIn Studio is the flagship experience in this repo: a single React workspace that bundles the Pokédex, AllergyFinder, STL viewer, and News Analyzer demos behind one shell. The live deployment is available at https://groq-allin.thefrenchartist.dev/. The `all_in` directory is the sole production target in this repository.
 
 ## Overview
 - `all_in/` contains the deployable Groq AllIn Studio workspace and is the recommended way to run the demos together.
-- `chat/`, `pokedex/`, `allergyfinder/`, and `groq-chat-stl-viewer/` mirror the original standalone projects that now ship inside Groq AllIn Studio.
 - The root `Makefile` provides install/run/test/deploy/clean commands for the Groq AllIn Studio workspace.
-- Production deployments target Groq AllIn Studio; the other directories are development artifacts.
+- Production deployments target Groq AllIn Studio.
 
 ## Prerequisites
-- Node.js 18+ and npm for Groq AllIn Studio and the other Vite/React frontends.
-- Python 3.10+ for the standalone Gradio apps in `chat/` and `pokedex/` (useful for local iteration).
+- Node.js 18+ and npm for Groq AllIn Studio.
 - A Groq API key for the browser clients (`.env.local` files are gitignored).
 
 ## Quick Start
@@ -23,15 +21,6 @@ Groq AllIn Studio is the flagship experience in this repo: a single React worksp
 - Production URL: https://groq-allin.thefrenchartist.dev/
 - Default dev port: `5175` (`ALLIN_PORT` overrides when using `make run`).
 
-### Legacy standalone demos (optional)
-These folders match the experiences embedded in Groq AllIn Studio and can still be run individually for debugging.
-- Install dependencies: `make install chat|pokedex|allergyfinder|stlviewer`
-- Launch a demo: `make run chat|pokedex|allergyfinder|stlviewer`
-- Test or lint: `make test chat|pokedex|allergyfinder|stlviewer`
-- Clean the shared Python virtualenv: `make clean`
-
-Default ports when run directly: Pokédex 7860, Chat 7861, AllergyFinder 5173, STL Viewer 5174. Override by exporting `POKEDEX_PORT`, `CHAT_PORT`, etc., before calling `make run`.
-
 ## Projects
 ### Groq AllIn Studio — React + Vite (primary target)
 Unified workspace with shared layout, navigation, and chat components. Switch between the embedded experiences via the top navigation. Configure per-experience chat endpoints with `.env.local` keys:
@@ -40,22 +29,10 @@ Unified workspace with shared layout, navigation, and chat components. Switch be
 
 **News Analyzer overview.** The News Analyzer workspace classifies the news of the day into “good” and “bad” buckets. It rotates through four GroqCloud-hosted LLMs—one request per second—to avoid HTTP429 (Too Many Requests) responses while still keeping the analysis stream steady. The interface already supports filtering by good or bad news, and an upcoming mixer will let you tune the blend to your preferred ratio. The underlying question the project explores: what balance of uplifting versus challenging stories helps someone feel informed without feeling overwhelmed?
 
-### Legacy Gradio apps
-- **Remote Chat (`chat/`)** — minimal Gradio UI that forwards prompts to a remote worker. Environment flags: `CHAT_BASE_URL` (default `https://groq-endpoint.louispaulet13.workers.dev`) and `CHAT_REQUEST_TIMEOUT` (seconds).
-- **Pokédex (`pokedex/`)** — local Gradio chat over a Pokédex dataset. Includes `pokedex/scripts/generate_pokemon_names.py` to refresh the derived name map.
-
-### Legacy React demos
-- **AllergyFinder (`allergyfinder/`)** — Groq-powered allergy assistant that enriches prompts with OpenFoodFacts lookups. Requires `VITE_GROQ_API_KEY`.
-- **Groq Chat STL Viewer (`groq-chat-stl-viewer/`)** — chat interface that renders inline 3D STL previews using `three.js` and a development `stl-proxy` helper. Requires `VITE_GROQ_API_KEY`.
-
 ## Extras
 - `demos/` — static HTML experiments for Groq streaming APIs.
-- `api_examples/` — quick tests (e.g., `test_openfoodfacts.html`) supporting AllergyFinder.
 
 ## Testing Notes
-- Groq AllIn Studio: `npm run lint` (inside `all_in/`).
-- Gradio apps: `make test chat` or `make test pokedex` (requires created virtualenv).
-- AllergyFinder: `cd allergyfinder && npm run lint` (also triggers `node --test` when using `make test allergyfinder`).
-- STL Viewer: `cd groq-chat-stl-viewer && npm run lint`.
+- Groq AllIn Studio: `npm run lint` and `npm run test` (inside `all_in/`) or `make test` from the repo root.
 
-Questions or tweaks? Check each subdirectory's README for deeper implementation details.
+Questions or tweaks? Check `all_in/README.md` for deeper implementation details.


### PR DESCRIPTION
## Summary
- update the root README to describe Groq AllIn Studio as the only production workspace
- prune references to removed legacy folders from prerequisites, extras, and testing notes

## Testing
- not run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2d38facb0832093b9978f4a707b0f