### PR TITLE
Add Flux image generation experience

### DIFF
--- a/all_in/src/App.jsx
+++ b/all_in/src/App.jsx
@@ -15,6 +15,7 @@ import ObjectMakerBuilder from './pages/ObjectMakerBuilder'
 import ObjectMakerZoo from './pages/ObjectMakerZoo'
 import NewsAnalyzerPage from './pages/NewsAnalyzerPage'
 import SixDegreesPage from './pages/SixDegreesPage'
+import ImageGeneratorPage from './pages/ImageGeneratorPage'
 
 export default function App() {
   return (
@@ -62,6 +63,16 @@ export default function App() {
                     )}
                   />
                 </Fragment>
+              ) : experience.id === 'imagegen' ? (
+                <Route
+                  key={experience.id}
+                  path={experience.path}
+                  element={(
+                    <ExperiencePage experience={experience}>
+                      <ImageGeneratorPage experience={experience} />
+                    </ExperiencePage>
+                  )}
+                />
               ) : experience.id === 'newsanalyzer' ? (
                 <Route
                   key={experience.id}

--- a/all_in/src/App.jsx
+++ b/all_in/src/App.jsx
@@ -16,6 +16,8 @@ import ObjectMakerZoo from './pages/ObjectMakerZoo'
 import NewsAnalyzerPage from './pages/NewsAnalyzerPage'
 import SixDegreesPage from './pages/SixDegreesPage'
 import ImageGeneratorPage from './pages/ImageGeneratorPage'
+import ImageGalleryPage from './pages/ImageGalleryPage'
+import ImageGeneratorNav from './components/imagegen/ImageGeneratorNav'
 
 export default function App() {
   return (
@@ -64,15 +66,24 @@ export default function App() {
                   />
                 </Fragment>
               ) : experience.id === 'imagegen' ? (
-                <Route
-                  key={experience.id}
-                  path={experience.path}
-                  element={(
-                    <ExperiencePage experience={experience}>
-                      <ImageGeneratorPage experience={experience} />
-                    </ExperiencePage>
-                  )}
-                />
+                <Fragment key={experience.id}>
+                  <Route
+                    path={experience.path}
+                    element={(
+                      <ExperiencePage experience={experience} navigation={<ImageGeneratorNav />}>
+                        <ImageGeneratorPage experience={experience} />
+                      </ExperiencePage>
+                    )}
+                  />
+                  <Route
+                    path={`${experience.path}/gallery`}
+                    element={(
+                      <ExperiencePage experience={experience} navigation={<ImageGeneratorNav />}>
+                        <ImageGalleryPage />
+                      </ExperiencePage>
+                    )}
+                  />
+                </Fragment>
               ) : experience.id === 'newsanalyzer' ? (
                 <Route
                   key={experience.id}

--- a/all_in/src/components/imagegen/ImageGeneratorNav.jsx
+++ b/all_in/src/components/imagegen/ImageGeneratorNav.jsx
@@ -1,0 +1,22 @@
+import { NavLink } from 'react-router-dom'
+
+function navClasses({ isActive }) {
+  const base =
+    'inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition border-slate-300 text-slate-700 hover:border-sky-500 hover:text-sky-600 dark:border-slate-700 dark:text-slate-200'
+  const active = 'bg-gradient-to-r from-sky-500 to-cyan-600 text-white border-transparent shadow'
+  return `${base} ${isActive ? active : ''}`
+}
+
+export default function ImageGeneratorNav() {
+  return (
+    <nav className="flex flex-wrap items-center gap-2">
+      <NavLink to="/imagegen" className={navClasses} end>
+        Generator
+      </NavLink>
+      <NavLink to="/imagegen/gallery" className={navClasses}>
+        Gallery
+      </NavLink>
+    </nav>
+  )
+}
+

--- a/all_in/src/config/experiences.js
+++ b/all_in/src/config/experiences.js
@@ -132,6 +132,30 @@ export const experiences = [
     defaultBaseUrl: (getEnvValue('VITE_POKEDEX_CHAT_BASE_URL') || FALLBACK_BASE_URL).replace(/\/$/, ''),
   },
   {
+    id: 'imagegen',
+    path: '/imagegen',
+    name: 'Flux Image Lab',
+    headline: 'Prompt → Flux image in seconds',
+    description:
+      'Send prompts to the Groq-hosted Flux endpoint, preview the returned image, and keep a cookie-backed gallery of recent hits.',
+    badge: 'Images',
+    heroGradient: 'from-sky-500 to-cyan-600',
+    panelAccent: 'bg-sky-100 text-sky-900 dark:bg-sky-500/20 dark:text-sky-200',
+    navAccent: {
+      gradient: 'from-sky-500 to-cyan-600',
+      hover:
+        'hover:bg-sky-500/10 hover:text-sky-600 hover:border-sky-400/60 dark:hover:bg-sky-500/20 dark:hover:text-sky-200 dark:hover:border-sky-400/60',
+      focus: 'focus-visible:ring-sky-500/40',
+    },
+    defaultModel: 'flux-image-endpoint',
+    modelOptions: ['Flux image endpoint'],
+    imageApiBaseUrl: (getEnvValue('VITE_IMAGE_API_BASE_URL') || FALLBACK_BASE_URL).replace(/\/$/, ''),
+    allowBaseUrlOverride: false,
+    enableStlViewer: false,
+    enableBarcodeScanner: false,
+    logLabel: 'ImageGen',
+  },
+  {
     id: 'newsanalyzer',
     path: '/newsanalyzer',
     name: 'News Analyzer',

--- a/all_in/src/lib/imageHistoryCookie.js
+++ b/all_in/src/lib/imageHistoryCookie.js
@@ -1,0 +1,67 @@
+const HISTORY_COOKIE_NAME = 'allin_flux_image_history'
+const MONTH_IN_SECONDS = 60 * 60 * 24 * 30
+const HISTORY_LIMIT = 6
+
+function getDocument() {
+  return typeof document === 'undefined' ? null : document
+}
+
+function readRawCookie(name) {
+  const doc = getDocument()
+  if (!doc || !doc.cookie) return ''
+  const cookies = doc.cookie.split('; ')
+  const target = cookies.find((cookie) => cookie.startsWith(`${name}=`))
+  if (!target) return ''
+  return target.split('=').slice(1).join('=')
+}
+
+function writeRawCookie(name, value, maxAgeSeconds = MONTH_IN_SECONDS) {
+  const doc = getDocument()
+  if (!doc) return
+  const encoded = encodeURIComponent(value)
+  const attributes = [`path=/`, `max-age=${maxAgeSeconds}`]
+  doc.cookie = `${name}=${encoded}; ${attributes.join('; ')}`
+}
+
+export function readImageHistory() {
+  const raw = readRawCookie(HISTORY_COOKIE_NAME)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw))
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map((entry) => ({
+        prompt: typeof entry?.prompt === 'string' ? entry.prompt : '',
+        url: typeof entry?.url === 'string' ? entry.url : '',
+        timestamp: typeof entry?.timestamp === 'number' ? entry.timestamp : Date.now(),
+      }))
+      .filter((entry) => entry.url)
+      .slice(0, HISTORY_LIMIT)
+  } catch {
+    return []
+  }
+}
+
+export function writeImageHistory(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    writeRawCookie(HISTORY_COOKIE_NAME, '[]')
+    return
+  }
+
+  const payload = entries
+    .filter((entry) => entry && typeof entry.url === 'string' && entry.url)
+    .slice(0, HISTORY_LIMIT)
+    .map((entry) => ({
+      prompt: typeof entry.prompt === 'string' ? entry.prompt : '',
+      url: entry.url,
+      timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : Date.now(),
+    }))
+
+  writeRawCookie(HISTORY_COOKIE_NAME, JSON.stringify(payload))
+}
+
+export function clearImageHistory() {
+  writeRawCookie(HISTORY_COOKIE_NAME, '[]', 0)
+}
+
+export const IMAGE_HISTORY_COOKIE_LIMIT = HISTORY_LIMIT

--- a/all_in/src/lib/imageHistoryCookie.js
+++ b/all_in/src/lib/imageHistoryCookie.js
@@ -1,6 +1,6 @@
 const HISTORY_COOKIE_NAME = 'allin_flux_image_history'
 const MONTH_IN_SECONDS = 60 * 60 * 24 * 30
-const HISTORY_LIMIT = 6
+const HISTORY_LIMIT = 60
 
 function getDocument() {
   return typeof document === 'undefined' ? null : document

--- a/all_in/src/pages/ImageGalleryPage.jsx
+++ b/all_in/src/pages/ImageGalleryPage.jsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { clearImageHistory, readImageHistory } from '../lib/imageHistoryCookie'
+
+const PAGE_SIZE = 12
+
+export default function ImageGalleryPage() {
+  const [entries, setEntries] = useState([])
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const sentinelRef = useRef(null)
+
+  const refreshHistory = useCallback(() => {
+    setEntries(readImageHistory())
+  }, [])
+
+  useEffect(() => {
+    refreshHistory()
+  }, [refreshHistory])
+
+  useEffect(() => {
+    setVisibleCount((current) => {
+      if (entries.length === 0) return PAGE_SIZE
+      const next = Math.max(PAGE_SIZE, current)
+      return Math.min(next, entries.length)
+    })
+  }, [entries.length])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleFocus = () => refreshHistory()
+    window.addEventListener('focus', handleFocus)
+
+    let handleVisibilityChange
+    if (typeof document !== 'undefined') {
+      handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          refreshHistory()
+        }
+      }
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+    }
+
+    return () => {
+      window.removeEventListener('focus', handleFocus)
+      if (handleVisibilityChange && typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }
+  }, [refreshHistory])
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) return undefined
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      setVisibleCount(entries.length)
+      return undefined
+    }
+
+    const observer = new IntersectionObserver((observerEntries) => {
+      observerEntries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setVisibleCount((current) => Math.min(current + PAGE_SIZE, entries.length))
+        }
+      })
+    })
+
+    observer.observe(node)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [entries.length])
+
+  const visibleEntries = useMemo(() => entries.slice(0, visibleCount), [entries, visibleCount])
+  const hasEntries = entries.length > 0
+  const hasMore = visibleCount < entries.length
+
+  function handleClearHistory() {
+    clearImageHistory()
+    setEntries([])
+    setVisibleCount(PAGE_SIZE)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Saved image gallery</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Browse every image saved to your browser cookie. Scroll to load more or refresh after generating new art.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            to="/imagegen"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-brand-400 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+          >
+            Back to generator
+          </Link>
+          <button
+            type="button"
+            onClick={refreshHistory}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-400 hover:text-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+          >
+            Refresh
+          </button>
+          {hasEntries ? (
+            <button
+              type="button"
+              onClick={handleClearHistory}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-red-400 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/30 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+            >
+              Clear all
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {hasEntries ? (
+        <>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleEntries.map((entry) => (
+              <article
+                key={`${entry.url}-${entry.timestamp}`}
+                className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white/80 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 dark:border-slate-700 dark:bg-slate-900/60"
+              >
+                <div className="relative aspect-square w-full overflow-hidden bg-slate-100 dark:bg-slate-800">
+                  <img src={entry.url} alt={entry.prompt || 'Generated image'} className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="space-y-2 p-4">
+                  <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    {entry.prompt || 'Saved image'}
+                  </h2>
+                  {entry.timestamp ? (
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      {new Date(entry.timestamp).toLocaleString()}
+                    </p>
+                  ) : null}
+                  <a
+                    href={entry.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-1.5 text-xs font-medium text-slate-600 transition hover:border-sky-400 hover:text-sky-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                  >
+                    Open original
+                  </a>
+                </div>
+              </article>
+            ))}
+          </div>
+          <div ref={sentinelRef} className="h-8 w-full" aria-hidden />
+          {!hasMore ? (
+            <p className="text-center text-sm text-slate-500 dark:text-slate-400">You&apos;ve reached the end of your saved images.</p>
+          ) : null}
+        </>
+      ) : (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white/60 p-10 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
+          No saved images yet. Generate something new and it will appear here automatically.
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/all_in/src/pages/ImageGeneratorPage.jsx
+++ b/all_in/src/pages/ImageGeneratorPage.jsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from 'react'
+import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { readImageHistory, writeImageHistory, clearImageHistory, IMAGE_HISTORY_COOKIE_LIMIT } from '../lib/imageHistoryCookie'
+
+function formatTimestamp(timestamp) {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function HistoryItem({ entry, onSelect }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(entry)}
+      className="flex flex-col items-start gap-1 rounded-xl border border-slate-200 bg-white/70 p-3 text-left shadow-sm transition hover:border-brand-400 hover:bg-brand-50/70 dark:border-slate-700 dark:bg-slate-900/60 dark:hover:border-brand-300"
+    >
+      <span className="text-sm font-medium text-slate-700 dark:text-slate-200">{entry.prompt || 'Saved image'}</span>
+      {entry.timestamp ? (
+        <span className="text-xs text-slate-500 dark:text-slate-400">{formatTimestamp(entry.timestamp)}</span>
+      ) : null}
+    </button>
+  )
+}
+
+export default function ImageGeneratorPage({ experience }) {
+  const [prompt, setPrompt] = useState('train speeding through a neon cyberpunk tunnel')
+  const [steps, setSteps] = useState('')
+  const [count, setCount] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState(null)
+  const [history, setHistory] = useState([])
+
+  useEffect(() => {
+    setHistory(readImageHistory())
+  }, [])
+
+  const apiBaseUrl = experience?.imageApiBaseUrl || 'https://groq-endpoint.louispaulet13.workers.dev'
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    const trimmedPrompt = prompt.trim()
+    if (!trimmedPrompt) {
+      setError('Please provide a prompt before generating an image.')
+      return
+    }
+
+    setLoading(true)
+    setError('')
+
+    try {
+      const requestUrl = new URL(`${apiBaseUrl.replace(/\/$/, '')}/flux/${encodeURIComponent(trimmedPrompt)}`)
+      const normalizedSteps = steps.trim()
+      const normalizedCount = count.trim()
+      if (normalizedSteps) {
+        requestUrl.searchParams.set('steps', normalizedSteps)
+      }
+      if (normalizedCount) {
+        requestUrl.searchParams.set('count', normalizedCount)
+      }
+
+      const response = await fetch(requestUrl.toString())
+      if (!response.ok) {
+        throw new Error(`Generation failed with status ${response.status}`)
+      }
+      const payload = await response.json()
+      const images = Array.isArray(payload?.images) ? payload.images : []
+      if (images.length === 0 || !images[0]?.url) {
+        throw new Error('The service did not return an image URL.')
+      }
+
+      const normalizedPrompt = typeof payload.prompt === 'string' && payload.prompt.trim() ? payload.prompt.trim() : trimmedPrompt
+      const nextResult = {
+        prompt: normalizedPrompt,
+        steps: payload.steps,
+        count: payload.count,
+        images: images.map((image, index) => ({
+          url: image?.url || '',
+          index: typeof image?.index === 'number' ? image.index : index,
+        })),
+        raw: payload,
+      }
+
+      setResult(nextResult)
+
+      const newEntry = {
+        prompt: normalizedPrompt,
+        url: nextResult.images[0].url,
+        timestamp: Date.now(),
+      }
+      const nextHistory = [newEntry, ...history.filter((item) => item.url !== newEntry.url)].slice(0, IMAGE_HISTORY_COOKIE_LIMIT)
+      setHistory(nextHistory)
+      writeImageHistory(nextHistory)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unexpected error during generation.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleSelectHistory(entry) {
+    if (!entry?.url) return
+    setPrompt(entry.prompt || '')
+    setResult({
+      prompt: entry.prompt,
+      steps: undefined,
+      count: undefined,
+      images: [{ url: entry.url, index: 0 }],
+      raw: null,
+    })
+  }
+
+  function handleClearHistory() {
+    clearImageHistory()
+    setHistory([])
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/60"
+        >
+          <div>
+            <label htmlFor="imagegen-prompt" className="flex items-center justify-between text-sm font-medium text-slate-700 dark:text-slate-200">
+              Image prompt
+              <span className="text-xs font-normal text-slate-400 dark:text-slate-500">Flux @ Groq endpoint</span>
+            </label>
+            <textarea
+              id="imagegen-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              rows={4}
+              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-sm text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400/50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              placeholder="Describe the image you want to see..."
+            />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              The request is sent to <code className="rounded bg-slate-100 px-1 py-0.5 text-[0.7rem] text-slate-700 dark:bg-slate-800 dark:text-slate-200">{`${apiBaseUrl}/flux/<prompt>`}</code>. We&apos;ll display the first image from the response.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <span className="font-medium">Steps (optional)</span>
+              <input
+                type="number"
+                min="1"
+                max="50"
+                value={steps}
+                onChange={(event) => setSteps(event.target.value)}
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400/50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                placeholder="e.g. 4"
+              />
+            </label>
+            <label className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <span className="font-medium">Count (optional)</span>
+              <input
+                type="number"
+                min="1"
+                max="6"
+                value={count}
+                onChange={(event) => setCount(event.target.value)}
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400/50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                placeholder="e.g. 2"
+              />
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2.5 text-sm font-medium text-white shadow transition hover:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:bg-brand-400 dark:focus-visible:ring-offset-slate-900"
+            >
+              <ArrowPathIcon className={`h-5 w-5 ${loading ? 'animate-spin' : ''}`} />
+              {loading ? 'Generating…' : 'Generate image'}
+            </button>
+            {history.length > 0 ? (
+              <button
+                type="button"
+                onClick={handleClearHistory}
+                className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-red-400 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/30 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-red-400 dark:hover:text-red-300 dark:focus-visible:ring-offset-slate-900"
+              >
+                <TrashIcon className="h-4 w-4" />
+                Clear saved images
+              </button>
+            ) : null}
+          </div>
+
+          {error ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-200">
+              {error}
+            </div>
+          ) : null}
+        </form>
+
+        <div className="space-y-4">
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white/80 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-600 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
+              Latest result
+            </div>
+            <div className="flex flex-col gap-4 p-4">
+              {result ? (
+                <>
+                  <div>
+                    <h3 className="text-sm font-medium text-slate-700 dark:text-slate-200">{result.prompt}</h3>
+                    {result.steps || result.count ? (
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {result.steps ? `steps: ${result.steps}` : ''}
+                        {result.steps && result.count ? ' · ' : ''}
+                        {result.count ? `count: ${result.count}` : ''}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-100 dark:border-slate-700 dark:bg-slate-800">
+                    <img src={result.images[0].url} alt={result.prompt} className="h-full w-full object-cover" loading="lazy" />
+                  </div>
+                  <a
+                    href={result.images[0].url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-medium text-slate-600 transition hover:border-brand-400 hover:text-brand-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                  >
+                    Open image in new tab
+                  </a>
+                </>
+              ) : (
+                <div className="text-sm text-slate-500 dark:text-slate-400">
+                  Submit a prompt to generate your first image. Your results will appear here.
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white/80 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-600 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
+              Saved images (browser cookie)
+            </div>
+            <div className="grid gap-3 p-4 sm:grid-cols-2">
+              {history.length === 0 ? (
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Generate an image to automatically store the image URL, prompt, and timestamp in a browser cookie for quick acce
+ss.
+                </p>
+              ) : (
+                history.map((entry) => (
+                  <HistoryItem key={`${entry.url}-${entry.timestamp}`} entry={entry} onSelect={handleSelectHistory} />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add the Flux Image Lab experience to the shared configuration and routes
- create an image generation workspace that calls the Groq Flux endpoint and previews results while saving history to cookies
- add a small cookie helper for persisting and clearing saved image metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2fa731d548320889b4dfd6002d194