### PR TITLE
Update README with Six Degrees and Flux highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Unified workspace with shared layout, navigation, and chat components. Switch be
 
 **News Analyzer overview.** The News Analyzer workspace classifies the news of the day into “good” and “bad” buckets. It rotates through four GroqCloud-hosted LLMs—one request per second—to avoid HTTP429 (Too Many Requests) responses while still keeping the analysis stream steady. The interface already supports filtering by good or bad news, and an upcoming mixer will let you tune the blend to your preferred ratio. The underlying question the project explores: what balance of uplifting versus challenging stories helps someone feel informed without feeling overwhelmed?
 
+**Six Degrees interface.** The Remix Lab now ships with the refreshed Six Degrees Of parody playground. It pairs the playful gradient shell from the React workspace with clearer copy, a progress pulse, and a timeline that retains every degree so you can scroll back through the transformation. The run panel accepts a seed sentence, locks while the six remix passes stream in from Groq, and lets you reset the canvas with one click when you are ready for a fresh prompt.
+
+**Flux image generation.** Flux-based image synthesis is now wired into the AllIn Studio shell. When the Flux backend is enabled through your environment variables the Image tab exposes prompts, negative prompts, resolution presets, seed locking, and a history rail so teams can keep their favorite generations. Flux runs on Groq hardware, so the UI highlights end-to-end latency, model variants (Flux Schnell and Flux Pro), and exposes a “reroll” shortcut for rapid iteration. This capability shares auth and rate limits with the other chat endpoints, so keep the same `.env.local` pattern when providing credentials.
+
 ## Extras
 - `demos/` — static HTML experiments for Groq streaming APIs.
 


### PR DESCRIPTION
## Summary
- document the refreshed Six Degrees parody interface in the Groq AllIn Studio section
- add guidance about the new Flux-powered image generation workflow and configuration hints

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2ffe591488320a9cf5d906e8e5abe