### PR TITLE
Hide Flux Image Lab and Pizza Maker from main navbar

### DIFF
--- a/all_in/src/components/layout/AppShell.jsx
+++ b/all_in/src/components/layout/AppShell.jsx
@@ -78,7 +78,9 @@ export default function AppShell({ children }) {
                 experience =>
                   experience.id !== 'objectmaker' &&
                   experience.id !== 'stlviewer' &&
-                  experience.id !== 'sixdegrees',
+                  experience.id !== 'sixdegrees' &&
+                  experience.id !== 'imagegen' &&
+                  experience.id !== 'pizzamaker',
               )
               .map((experience) => (
               <NavLink


### PR DESCRIPTION
## Summary
- update the main navbar filter to exclude the Flux Image Lab and Pizza Maker experiences
- keep those experiences accessible elsewhere without crowding the top navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4041e32308320a70092c8c3f5f37a