### PR TITLE
Add cookie-backed pizza gallery and profile stats

### DIFF
--- a/all_in/src/components/allergyfinder/UserProfile.jsx
+++ b/all_in/src/components/allergyfinder/UserProfile.jsx
@@ -18,6 +18,7 @@ import {
   clearNewsClassificationCount,
   readNewsClassificationCount,
 } from '../../lib/newsAnalyzerStats'
+import { clearPizzaGallery, countPizzaGalleryEntries } from '../../lib/pizzaGalleryCookie'
 
 const CHAT_EXPERIENCE_LABELS = {
   allergyfinder: 'AllergyFinder',
@@ -56,6 +57,7 @@ export default function UserProfile() {
   const [allergyItems, setAllergyItems] = useState(() => parseAllergyList(readAllergyCookie()))
   const [objectCount, setObjectCount] = useState(() => countZooEntries())
   const [newsClassificationCount, setNewsClassificationCount] = useState(() => readNewsClassificationCount())
+  const [pizzaGalleryCount, setPizzaGalleryCount] = useState(0)
 
   useEffect(() => {
     let stored = readUserProfileName()
@@ -73,6 +75,7 @@ export default function UserProfile() {
     setAllergyItems(parseAllergyList(readAllergyCookie()))
     setObjectCount(countZooEntries())
     setNewsClassificationCount(readNewsClassificationCount())
+    setPizzaGalleryCount(countPizzaGalleryEntries())
   }
 
   function handleRegenerateProfile() {
@@ -113,6 +116,11 @@ export default function UserProfile() {
 
   function handleResetNewsStats() {
     clearNewsClassificationCount()
+    refreshStats()
+  }
+
+  function handleClearPizzaGallery() {
+    clearPizzaGallery()
     refreshStats()
   }
 
@@ -160,6 +168,17 @@ export default function UserProfile() {
       onReset: handleClearObjectMaker,
       resetLabel: 'Delete saved objects',
       footnote: 'Removes every object stored in the Object Maker Zoo on this device.',
+    },
+    {
+      id: 'pizzamaker',
+      label: 'Pizza Maker',
+      icon: '🍕',
+      value: pizzaGalleryCount,
+      description: 'Pizzas saved to your cookie-backed gallery.',
+      cta: { to: '/pizza-maker', label: 'Open Pizza Maker' },
+      onReset: handleClearPizzaGallery,
+      resetLabel: 'Clear pizza gallery',
+      footnote: 'Deletes every saved pizza render stored in browser cookies.',
     },
     {
       id: 'newsanalyzer',

--- a/all_in/src/lib/pizzaGalleryCookie.js
+++ b/all_in/src/lib/pizzaGalleryCookie.js
@@ -1,0 +1,90 @@
+const PIZZA_GALLERY_COOKIE_NAME = 'allin_pizza_gallery'
+const MONTH_IN_SECONDS = 60 * 60 * 24 * 30
+const PIZZA_GALLERY_LIMIT = 40
+
+function getDocument() {
+  return typeof document === 'undefined' ? null : document
+}
+
+function readRawCookie(name) {
+  const doc = getDocument()
+  if (!doc || !doc.cookie) return ''
+  const cookies = doc.cookie.split('; ')
+  const target = cookies.find((cookie) => cookie.startsWith(`${name}=`))
+  if (!target) return ''
+  return target.split('=').slice(1).join('=')
+}
+
+function writeRawCookie(name, value, maxAgeSeconds = MONTH_IN_SECONDS) {
+  const doc = getDocument()
+  if (!doc) return
+  const encoded = encodeURIComponent(value)
+  const attributes = [`path=/`, `max-age=${maxAgeSeconds}`]
+  doc.cookie = `${name}=${encoded}; ${attributes.join('; ')}`
+}
+
+function normaliseEntry(entry) {
+  if (!entry || typeof entry.url !== 'string' || !entry.url.trim()) {
+    return null
+  }
+
+  return {
+    prompt: typeof entry.prompt === 'string' ? entry.prompt : '',
+    url: entry.url,
+    summary: typeof entry.summary === 'string' ? entry.summary : '',
+    timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : Date.now(),
+  }
+}
+
+export function readPizzaGallery() {
+  const raw = readRawCookie(PIZZA_GALLERY_COOKIE_NAME)
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw))
+    if (!Array.isArray(parsed)) return []
+
+    return parsed
+      .map((entry) => normaliseEntry(entry))
+      .filter(Boolean)
+      .slice(0, PIZZA_GALLERY_LIMIT)
+  } catch {
+    return []
+  }
+}
+
+export function writePizzaGallery(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    writeRawCookie(PIZZA_GALLERY_COOKIE_NAME, '[]')
+    return
+  }
+
+  const payload = entries
+    .map((entry) => normaliseEntry(entry))
+    .filter(Boolean)
+    .slice(0, PIZZA_GALLERY_LIMIT)
+
+  writeRawCookie(PIZZA_GALLERY_COOKIE_NAME, JSON.stringify(payload))
+}
+
+export function appendPizzaGalleryEntry(entry) {
+  const normalised = normaliseEntry(entry)
+  if (!normalised) {
+    return readPizzaGallery()
+  }
+
+  const existing = readPizzaGallery().filter((item) => item.url !== normalised.url)
+  const next = [normalised, ...existing].slice(0, PIZZA_GALLERY_LIMIT)
+  writePizzaGallery(next)
+  return next
+}
+
+export function clearPizzaGallery() {
+  writeRawCookie(PIZZA_GALLERY_COOKIE_NAME, '[]', 0)
+}
+
+export function countPizzaGalleryEntries() {
+  return readPizzaGallery().length
+}
+
+export { PIZZA_GALLERY_LIMIT, PIZZA_GALLERY_COOKIE_NAME }


### PR DESCRIPTION
## Summary
- add a dedicated cookie helper to persist pizza renders and metadata
- show a saved pizza gallery on the Pizza Maker page with timestamps and a clear button
- surface the pizza gallery count and reset control on the Profile experience snapshot

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68e40464e3dc83208c3cdc84500709e9