### PR TITLE
Implement chunked cookie storage for history data

### DIFF
--- a/ROOT_CAUSE.md
+++ b/ROOT_CAUSE.md
@@ -1,0 +1,12 @@
+# Root Cause Analysis: Missing Saved Conversations and Images
+
+## Summary
+- Chat conversations were stored in a single cookie with aggressive limits (two conversations and six messages each). Once the cap was hit, subsequent chats replaced older ones and message bodies were truncated, leading to missing and cropped history in the UI.
+- Generated image metadata was constrained to 60 entries in a single cookie. When the gallery reached that limit, newer renders were dropped instead of being appended, making the gallery appear "full".
+- Both features relied on singular cookies capped around 3.5 KB. Larger histories silently failed to persist because the payload exceeded the cookie size, so nothing beyond the truncated data was retrievable.
+
+## Fixes
+- Added a shared chunked cookie helper that transparently splits large JSON payloads across sequential cookies and rejoins them when reading. Legacy single-cookie data is still readable.
+- Updated conversation persistence to remove artificial caps, retain every message, and rely on the chunked cookies for storage. Ordering now mirrors the in-memory conversation list.
+- Updated image history persistence to reuse the chunked helper, removing the gallery cap so every saved render is recoverable in order.
+- Expanded the automated tests to cover the unbounded history behaviour and ensure chunked cookies are created and cleared correctly.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+- [x] Audit existing cookie storage for conversations and image galleries to identify truncation and missing data causes.
+- [x] Introduce a shared chunked cookie utility for storing large JSON payloads.
+- [x] Update conversation persistence to store full histories without cropping and maintain order.
+- [x] Update image gallery persistence to store all saved images using the shared utility.
+- [x] Add or update unit tests covering the new cookie storage behaviour for chats and images.
+- [x] Run the relevant test suites to confirm everything passes.
+- [x] Document the root causes and fixes in a report.

--- a/all_in/src/lib/cookieUtils.js
+++ b/all_in/src/lib/cookieUtils.js
@@ -1,0 +1,108 @@
+const DEFAULT_MAX_AGE = 60 * 60 * 24 * 365
+const DEFAULT_CHUNK_SIZE = 3500
+
+function getDocument() {
+  return typeof document === 'undefined' ? null : document
+}
+
+function parseCookies(doc = getDocument()) {
+  if (!doc || !doc.cookie) return []
+  return doc.cookie
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const eqIndex = entry.indexOf('=')
+      if (eqIndex === -1) {
+        return { name: entry, value: '' }
+      }
+      return {
+        name: entry.slice(0, eqIndex),
+        value: entry.slice(eqIndex + 1),
+      }
+    })
+}
+
+function readCookieValue(name) {
+  if (!name) return ''
+  const match = parseCookies().find((cookie) => cookie.name === name)
+  return match ? match.value : ''
+}
+
+function writeCookie(name, value, maxAgeSeconds = DEFAULT_MAX_AGE) {
+  const doc = getDocument()
+  if (!doc || !name) return
+  const encoded = encodeURIComponent(value)
+  doc.cookie = `${name}=${encoded}; path=/; max-age=${maxAgeSeconds}`
+}
+
+function deleteCookie(name) {
+  const doc = getDocument()
+  if (!doc || !name) return
+  doc.cookie = `${name}=; path=/; max-age=0`
+}
+
+function clearChunkedCookie(name) {
+  const doc = getDocument()
+  if (!doc || !name || !doc.cookie) return
+  const prefix = `${name}__`
+  parseCookies(doc)
+    .filter((cookie) => cookie.name === name || cookie.name.startsWith(prefix))
+    .forEach((cookie) => {
+      doc.cookie = `${cookie.name}=; path=/; max-age=0`
+    })
+}
+
+function readChunkedCookie(name) {
+  if (!name) return ''
+  const prefix = `${name}__`
+  const chunks = parseCookies()
+    .filter((cookie) => cookie.name === name || cookie.name.startsWith(prefix))
+    .map((cookie) => ({
+      name: cookie.name,
+      value: cookie.value || '',
+      index: cookie.name === name ? 0 : Number.parseInt(cookie.name.slice(prefix.length), 10),
+    }))
+    .filter((chunk) => Number.isInteger(chunk.index) && chunk.index >= 0)
+    .sort((a, b) => a.index - b.index)
+  if (chunks.length === 0) return ''
+  const encoded = chunks.map((chunk) => chunk.value).join('')
+  if (!encoded) return ''
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return ''
+  }
+}
+
+function writeChunkedCookie(name, value, { maxAgeSeconds = DEFAULT_MAX_AGE, chunkSize = DEFAULT_CHUNK_SIZE } = {}) {
+  const doc = getDocument()
+  if (!doc || !name) return
+  const payload = typeof value === 'string' ? value : JSON.stringify(value)
+  if (!payload) {
+    clearChunkedCookie(name)
+    return
+  }
+  const encoded = encodeURIComponent(payload)
+  const size = Math.max(1, Number.parseInt(chunkSize, 10) || DEFAULT_CHUNK_SIZE)
+  clearChunkedCookie(name)
+  for (let index = 0; index * size < encoded.length; index += 1) {
+    const start = index * size
+    const segment = encoded.slice(start, start + size)
+    const chunkName = index === 0 ? name : `${name}__${index}`
+    doc.cookie = `${chunkName}=${segment}; path=/; max-age=${maxAgeSeconds}`
+  }
+}
+
+export {
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_MAX_AGE,
+  clearChunkedCookie,
+  deleteCookie,
+  getDocument,
+  parseCookies,
+  readChunkedCookie,
+  readCookieValue,
+  writeChunkedCookie,
+  writeCookie,
+}

--- a/all_in/src/lib/imageHistoryCookie.test.js
+++ b/all_in/src/lib/imageHistoryCookie.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { clearImageHistory, readImageHistory, writeImageHistory } from './imageHistoryCookie'
+import { installCookieStub } from './testCookieStub'
+
+const cookieStub = installCookieStub()
+
+beforeEach(() => {
+  cookieStub.reset()
+})
+
+describe('image history cookie persistence', () => {
+  test('stores full history without truncation and preserves ordering', () => {
+    const now = Date.now()
+    const entries = Array.from({ length: 80 }, (_, index) => ({
+      url: `https://example.com/${index}.png`,
+      prompt: `Prompt ${index}`,
+      timestamp: now + index,
+    }))
+
+    writeImageHistory(entries)
+
+    const saved = readImageHistory()
+    expect(saved).toHaveLength(entries.length)
+    expect(saved[0]).toEqual(entries[0])
+    expect(saved.at(-1)).toEqual(entries.at(-1))
+  })
+
+  test('splits large payloads across multiple cookies', () => {
+    const now = Date.now()
+    writeImageHistory([
+      {
+        url: 'https://example.com/giant.png',
+        prompt: 'l'.repeat(6000),
+        timestamp: now,
+      },
+    ])
+
+    const cookies = cookieStub.snapshot()
+    const keys = Object.keys(cookies).filter((key) => key.startsWith('allin_flux_image_history'))
+    expect(keys.length).toBeGreaterThan(1)
+  })
+
+  test('clears all cookie chunks when history is removed', () => {
+    writeImageHistory([
+      { url: 'https://example.com/1.png', prompt: 'one', timestamp: Date.now() },
+      { url: 'https://example.com/2.png', prompt: 'two', timestamp: Date.now() + 1 },
+    ])
+
+    clearImageHistory()
+
+    const cookies = cookieStub.snapshot()
+    const keys = Object.keys(cookies).filter((key) => key.startsWith('allin_flux_image_history'))
+    expect(keys).toHaveLength(0)
+    expect(readImageHistory()).toHaveLength(0)
+  })
+})

--- a/all_in/src/lib/testCookieStub.js
+++ b/all_in/src/lib/testCookieStub.js
@@ -1,0 +1,40 @@
+export function installCookieStub() {
+  let store = {}
+  const cookieDescriptor = {
+    configurable: true,
+    get() {
+      return Object.entries(store)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('; ')
+    },
+    set(value) {
+      if (typeof value !== 'string') return
+      const [pair, ...attrs] = value.split(';')
+      const [rawName, ...rest] = pair.split('=')
+      const name = rawName.trim()
+      const encodedValue = rest.join('=').trim()
+      if (!name) return
+      const normalizedAttrs = attrs.map((item) => item.trim().toLowerCase())
+      if (normalizedAttrs.some((attr) => attr === 'max-age=0')) {
+        delete store[name]
+        return
+      }
+      store[name] = encodedValue
+    },
+  }
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {},
+  })
+  Object.defineProperty(globalThis.document, 'cookie', cookieDescriptor)
+
+  return {
+    reset() {
+      store = {}
+    },
+    snapshot() {
+      return { ...store }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable chunked cookie utility to support larger payloads
- update chat and image history persistence to remove legacy limits and use chunked cookies
- expand unit tests and documentation around the cookie fixes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e40ca7bc588320bd6ce3046449144c